### PR TITLE
Add address field to analytics_events

### DIFF
--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -36,7 +36,7 @@ export class FormoAnalytics implements IFormoAnalytics {
   }
 
   private identifyUser(userData: any) {
-    this.trackEvent('identify_user', userData);
+    this.trackEvent('identify', userData);
   }
 
   private getSessionId() {
@@ -84,12 +84,13 @@ export class FormoAnalytics implements IFormoAnalytics {
     const apiUrl = this.buildApiUrl();
 
     const requestData = {
+      project_id: this.projectId,
+      address: '', // TODO: get cached / session wallet address
+      session_id: this.getSessionId(),
       timestamp: new Date().toISOString(),
       action: action,
       version: '1',
-      session_id: this.getSessionId(),
       payload: isNotEmpty(payload) ? this.maskSensitiveData(payload) : payload,
-      project_id: this.projectId,
     };
 
     console.log('Request data:', JSON.stringify(requestData));


### PR DESCRIPTION
In https://github.com/getformo/formono/pull/93/files, we are adding `address` to `analytics_events` datasource.

In the payload we send to tinybird we will need to always include this field, even if it's empty.

@kiuthy229 

In the future, we will need to detect the visitor's connected wallet address and cache / store it in session for all events emitted in the the duration of the session. See how connection / disconnection is handled in https://github.com/0xarc-io/analytics-sdk?tab=readme-ov-file#disconnection

Example Sequence:
- session id created
- connected wallet address A detected
- use this wallet address A for events emitted this session
- if disconnect wallet event detect, use empty wallet address for subsequent events this session
- new connected wallet address B detected
- use this wallet address B for events emitted the rest of this session
