### PR TITLE
chore: update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formo/analytics",
-  "version": "1.0.1",
+  "version": "1.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/getformo/sdk.git"


### PR DESCRIPTION
<img width="465" alt="Screenshot 2024-10-31 at 15 53 57" src="https://github.com/user-attachments/assets/9ae5b64f-96f9-4890-92dc-a1c98a1f09a3">
<img width="329" alt="Screenshot 2024-10-31 at 15 53 48" src="https://github.com/user-attachments/assets/7fe6a796-39b3-41fd-b904-63376aa80276">

There are hidden versions that have been used while I was testing the package. I've no idea how to clear up so we start with `1.8.0` for now (lastest so we will not ever again run into error "previously published version")