### PR TITLE
Fix identify

### DIFF
--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -30,7 +30,6 @@ import {
   SignatureStatus,
   TransactionStatus,
 } from "./types";
-import { generateNativeUUID } from "./utils";
 import { isAddress, isLocalhost } from "./validators";
 
 interface IFormoAnalytics {
@@ -97,6 +96,9 @@ interface IFormoAnalytics {
     providerName?: string;
     userId?: string;
     rdns?: string;
+    properties?: IFormoEventProperties,
+    context?: IFormoEventContext,
+    callback?: (...args: unknown[]) => void
   }): Promise<void>;
   track(
     event: string,


### PR DESCRIPTION
Identify can no longer autodetect addresses, only an explicit connect event can get it now.

This PR simplifies the `identify` function