### PR TITLE
Include address in connect and disconnect event properties

### DIFF
--- a/src/lib/event/EventFactory.ts
+++ b/src/lib/event/EventFactory.ts
@@ -377,6 +377,7 @@ class EventFactory implements IEventFactory {
     const signatureEvent: Partial<IFormoEvent> = {
       properties: {
         status,
+        address,
         chainId,
         message,
         signatureHash,
@@ -403,6 +404,7 @@ class EventFactory implements IEventFactory {
     const transactionEvent: Partial<IFormoEvent> = {
       properties: {
         status,
+        address,
         chainId,
         data,
         to,


### PR DESCRIPTION
Event properties should include all relevant fields here, and the address of the connect / disconnect should be in the properties