### PR TITLE
fix(SDK): Fix empty transaction hash error, track confirmed and reverted status

### DIFF
--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -641,6 +641,8 @@ export class FormoAnalytics implements IFormoAnalytics {
       method,
       params,
     }: RequestArguments): Promise<T | null | undefined> => {
+      // TODO: Add support for other transaction methods (eip5792.xyz)
+
       if (
         Array.isArray(params) &&
         method === "eth_sendTransaction" &&
@@ -661,7 +663,7 @@ export class FormoAnalytics implements IFormoAnalytics {
             transactionHash,
           });
 
-          return;
+          return transactionHash as T;
         } catch (error) {
           logger.error("Transaction error:", error);
           const rpcError = error as RPCError;

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -1037,7 +1037,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     transactionHash: string,
     payload: any,
     maxAttempts = 10,
-    intervalMs = 2000
+    intervalMs = 3000
   ) {
     let attempts = 0;
     const provider = this.provider;

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -427,7 +427,7 @@ export class FormoAnalytics implements IFormoAnalytics {
 
       // Explicit identify
       const { userId, address, providerName, rdns } = params;
-      logger.debug("Identify", address, userId, providerName, rdns);      
+      logger.debug("Identify", address, userId, providerName, rdns);
       if (address) this.currentAddress = address;
       if (userId) {
         this.currentUserId = userId;
@@ -569,7 +569,7 @@ export class FormoAnalytics implements IFormoAnalytics {
   }
 
   private registerRequestListeners(): void {
-    console.debug("registerRequestListeners");
+    logger.debug("registerRequestListeners");
     if (!this.provider) {
       logger.error("Provider not found for request (signature, transaction) tracking");
       return;

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -543,13 +543,13 @@ export class FormoAnalytics implements IFormoAnalytics {
       // Register listeners for web3 provider events
       this.registerAddressChangedListener();
       this.registerChainChangedListener();
-      this._registerRequestListeners();
+      this.registerRequestListeners();
     } catch (error) {
       logger.error("Error tracking provider:", error);
     }
   }
 
-  private _registerRequestListeners(): void {
+  private registerRequestListeners(): void {
     if (!this.provider) {
       logger.error("Provider not found for request tracking");
       return;
@@ -562,7 +562,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       return;
     }
 
-    const originalRequest = this.provider.request.bind(this.provider);
+    const request = this.provider.request.bind(this.provider);
 
     this.provider.request = async <T>({
       method,
@@ -586,7 +586,7 @@ export class FormoAnalytics implements IFormoAnalytics {
         })();
 
         try {
-          const response = (await originalRequest({ method, params })) as T;
+          const response = (await request({ method, params })) as T;
           (async () => {
             try {
               if (response) {
@@ -634,7 +634,7 @@ export class FormoAnalytics implements IFormoAnalytics {
         })();
 
         try {
-          const transactionHash = (await originalRequest({
+          const transactionHash = (await request({
             method,
             params,
           })) as string;
@@ -677,7 +677,7 @@ export class FormoAnalytics implements IFormoAnalytics {
         }
       }
 
-      return originalRequest({ method, params });
+      return request({ method, params });
     };
   }
 

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -663,7 +663,23 @@ export class FormoAnalytics implements IFormoAnalytics {
             transactionHash,
           });
 
-          return transactionHash as T;
+          // Wait for transaction confirmation
+          const receipt = await this.provider?.request({
+            method: "eth_getTransactionReceipt",
+            params: [transactionHash],
+          });
+
+          // Track transaction confirmation
+          this.transaction(
+            {
+              status: TransactionStatus.CONFIRMED,
+              ...payload,
+              transactionHash,
+            },
+            receipt as IFormoEventProperties
+          );
+
+          return transactionHash as unknown as T;
         } catch (error) {
           logger.error("Transaction error:", error);
           const rpcError = error as RPCError;

--- a/src/FormoAnalyticsProvider.tsx
+++ b/src/FormoAnalyticsProvider.tsx
@@ -24,12 +24,12 @@ export const FormoAnalyticsProvider = (props: FormoAnalyticsProviderProps) => {
 
   // Keep the app running without analytics if no Write Key is provided or disabled
   if (!writeKey) {
-    console.error("FormoAnalyticsProvider: No Write Key provided");
+    logger.error("FormoAnalyticsProvider: No Write Key provided");
     return children;
   }
 
   if (disabled) {
-    console.warn("FormoAnalytics is disabled");
+    logger.warn("FormoAnalytics is disabled");
     return children;
   }
 
@@ -49,9 +49,9 @@ const InitializedAnalytics = ({
     try {
       const sdkInstance = await FormoAnalytics.init(writeKey, options);
       setSdk(sdkInstance);
-      console.log("Formo SDK initialized :)");
+      logger.log("Successfully initialized :)");
     } catch (error) {
-      console.error("Failed to initialize Formo SDK :(", error);
+      logger.error("Failed to initialize :(", error);
     }
   };
 

--- a/src/FormoAnalyticsProvider.tsx
+++ b/src/FormoAnalyticsProvider.tsx
@@ -49,9 +49,9 @@ const InitializedAnalytics = ({
     try {
       const sdkInstance = await FormoAnalytics.init(writeKey, options);
       setSdk(sdkInstance);
-      console.log("FormoAnalytics SDK initialized successfully");
+      console.log("Formo SDK initialized :)");
     } catch (error) {
-      console.error("Failed to initialize FormoAnalytics SDK", error);
+      console.error("Failed to initialize Formo SDK :(", error);
     }
   };
 

--- a/src/lib/event/EventFactory.ts
+++ b/src/lib/event/EventFactory.ts
@@ -348,7 +348,7 @@ class EventFactory implements IEventFactory {
     chainId: ChainID,
     address: Address,
     message: string,
-    signatureHash: string,
+    signatureHash?: string,
     properties?: IFormoEventProperties,
     context?: IFormoEventContext
   ) {
@@ -357,7 +357,7 @@ class EventFactory implements IEventFactory {
         status,
         chainId,
         message,
-        signatureHash,
+        ...(signatureHash && { signatureHash }),
         ...properties,
       },
       address,
@@ -374,7 +374,7 @@ class EventFactory implements IEventFactory {
     data: string,
     to: string,
     value: string,
-    transactionHash: string,
+    transactionHash?: string,
     properties?: IFormoEventProperties,
     context?: IFormoEventContext
   ) {
@@ -385,7 +385,7 @@ class EventFactory implements IEventFactory {
         data,
         to,
         value,
-        transactionHash,
+        ...(transactionHash && { transactionHash }),
         ...properties,
       },
       address,

--- a/src/lib/logger/Logger.ts
+++ b/src/lib/logger/Logger.ts
@@ -73,7 +73,7 @@ export class Logger implements ILogger {
       second: "2-digit",
       hour12: false,
     });
-    return `[Formo Analytics][${timestamp}] ${message}`;
+    return `[Formo SDK][${timestamp}] ${message}`;
   }
 
   public debug(message: string, ...args: any[]): void {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -124,4 +124,5 @@ export enum TransactionStatus {
   REJECTED = "rejected",
   BROADCASTED = "broadcasted",
   CONFIRMED = "confirmed",
+  REVERTED = "reverted",
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -123,4 +123,5 @@ export enum TransactionStatus {
   STARTED = "started",
   REJECTED = "rejected",
   BROADCASTED = "broadcasted",
+  CONFIRMED = "confirmed",
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -69,7 +69,7 @@ export interface TransactionAPIEvent {
   data: string;
   to: string;
   value: string;
-  transactionHash: string;
+  transactionHash?: string;
 }
 export interface SignatureAPIEvent {
   type: "signature";
@@ -77,7 +77,7 @@ export interface SignatureAPIEvent {
   chainId: ChainID;
   address: Address;
   message: string;
-  signatureHash: string;
+  signatureHash?: string;
 }
 export interface ConnectAPIEvent {
   type: "connect";


### PR DESCRIPTION
Fixes an error where empty transaction hash is returned

```
web3validatorError: Web3 validator found 1 error[s]: value "null" at "/0" must pass "bytes32" validation
```

Also:
- Refactored signature and transaction tracking to be async and not in the critical path
- Tracked transaction confirmed and reverted 