### PR TITLE
Refactor provider event listeners

### DIFF
--- a/src/FormoAnalyticsProvider.tsx
+++ b/src/FormoAnalyticsProvider.tsx
@@ -9,7 +9,6 @@ const defaultContext: IFormoAnalytics = {
   reset: () => Promise.resolve(),
   detect: () => Promise.resolve(),
   connect: () => Promise.resolve(),
-  disconnect: () => Promise.resolve(),
   signature: () => Promise.resolve(),
   transaction: () => Promise.resolve(),
   identify: () => Promise.resolve(),

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -36,12 +36,6 @@ export interface IFormoAnalytics {
     context?: IFormoEventContext,
     callback?: (...args: unknown[]) => void
   ): Promise<void>;
-  disconnect(
-    params?: { chainId?: ChainID; address?: Address },
-    properties?: IFormoEventProperties,
-    context?: IFormoEventContext,
-    callback?: (...args: unknown[]) => void
-  ): Promise<void>;
   chain(
     params: { chainId: ChainID; address?: Address },
     properties?: IFormoEventProperties,

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -15,3 +15,7 @@ export interface RPCError extends Error {
   code: number;
   data?: unknown;
 }
+
+export interface ConnectInfo {
+  chainId: string;
+}

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,0 +1,12 @@
+/**
+ * Parses a chainId string (hex or decimal) to a number.
+ * @param chainId - The chainId as a string (e.g., '0x1', '1')
+ * @returns The chainId as a number
+ */
+export function parseChainId(chainId: string): number {
+  if (typeof chainId !== 'string') return 0;
+  if (chainId.startsWith('0x') || chainId.startsWith('0X')) {
+    return parseInt(chainId, 16);
+  }
+  return parseInt(chainId, 10);
+} 

--- a/src/validators/address.ts
+++ b/src/validators/address.ts
@@ -4,7 +4,7 @@ import { utf8ToBytes } from "ethereum-cryptography/utils.js";
 import { ValidInputTypes } from "../types";
 import { isHexStrict } from "./string";
 
-export const isAddress = (value: ValidInputTypes, checkChecksum = true) => {
+export const isAddress = (value: ValidInputTypes, checksum = true) => {
   if (typeof value !== "string" && !isUint8Array(value)) {
     return false;
   }
@@ -31,10 +31,10 @@ export const isAddress = (value: ValidInputTypes, checkChecksum = true) => {
     return true;
     // Otherwise check each case
   }
-  return checkChecksum ? checkAddressCheckSum(valueToCheck) : true;
+  return checksum ? checkAddressChecksum(valueToCheck) : true;
 };
 
-export const checkAddressCheckSum = (data: string): boolean => {
+export const checkAddressChecksum = (data: string): boolean => {
   if (!/^(0x)?[0-9a-f]{40}$/i.test(data)) return false;
   const address = data.slice(2);
   const updatedData = utf8ToBytes(address.toLowerCase());


### PR DESCRIPTION
Refactor listeners https://docs.metamask.io/wallet/reference/provider-api/#events

- Remove 'disconnect' event because it's an error event and not a user event https://docs.phantom.com/ethereum-monad-testnet-base-and-polygon/provider-api-reference/events/disconnect

> Event emitted upon the wallet losing connection to the RPC provider.
>
> This is not a user "disconnecting" from a dapp, or otherwise revoking access between the dapp and the wallet.