### PR TITLE
fix(sdk) Fix type for FormoAnalyticsProvider

### DIFF
--- a/src/FormoAnalyticsProvider.tsx
+++ b/src/FormoAnalyticsProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react";
 import { FormoAnalytics } from "./FormoAnalytics";
 import { initStorageManager, logger } from "./lib";
 import { FormoAnalyticsProviderProps, IFormoAnalytics } from "./types";
@@ -19,7 +19,7 @@ const defaultContext: IFormoAnalytics = {
 export const FormoAnalyticsContext =
   createContext<IFormoAnalytics>(defaultContext);
 
-export const FormoAnalyticsProvider = (props: FormoAnalyticsProviderProps) => {
+export const FormoAnalyticsProvider = (props: FormoAnalyticsProviderProps): ReactNode => {
   const { writeKey, disabled = false, children } = props;
 
   // Keep the app running without analytics if no Write Key is provided or disabled
@@ -40,27 +40,23 @@ const InitializedAnalytics = ({
   writeKey,
   options,
   children,
-}: FormoAnalyticsProviderProps) => {
+}: FormoAnalyticsProviderProps): ReactNode => {
   const [sdk, setSdk] = useState<IFormoAnalytics>(defaultContext);
   const initializedStartedRef = useRef(false);
   initStorageManager(writeKey);
-
-  const initializeFormoAnalytics = async (writeKey: string, options: any) => {
-    try {
-      const sdkInstance = await FormoAnalytics.init(writeKey, options);
-      setSdk(sdkInstance);
-      logger.log("Successfully initialized :)");
-    } catch (error) {
-      logger.error("Failed to initialize :(", error);
-    }
-  };
 
   useEffect(() => {
     const initialize = async () => {
       if (initializedStartedRef.current) return;
       initializedStartedRef.current = true;
 
-      await initializeFormoAnalytics(writeKey!, options);
+      try {
+        const sdkInstance = await FormoAnalytics.init(writeKey!, options);
+        setSdk(sdkInstance);
+        logger.log("Successfully initialized :)");
+      } catch (error) {
+        logger.error("Failed to initialize :(", error);
+      }
     };
 
     initialize();

--- a/src/FormoAnalyticsProvider.tsx
+++ b/src/FormoAnalyticsProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react";
+import { createContext, useContext, useEffect, useRef, useState, ReactNode, FC } from "react";
 import { FormoAnalytics } from "./FormoAnalytics";
 import { initStorageManager, logger } from "./lib";
 import { FormoAnalyticsProviderProps, IFormoAnalytics } from "./types";
@@ -19,28 +19,28 @@ const defaultContext: IFormoAnalytics = {
 export const FormoAnalyticsContext =
   createContext<IFormoAnalytics>(defaultContext);
 
-export const FormoAnalyticsProvider = (props: FormoAnalyticsProviderProps): ReactNode => {
+export const FormoAnalyticsProvider: FC<FormoAnalyticsProviderProps> = (props) => {
   const { writeKey, disabled = false, children } = props;
 
   // Keep the app running without analytics if no Write Key is provided or disabled
   if (!writeKey) {
     logger.error("FormoAnalyticsProvider: No Write Key provided");
-    return children;
+    return <>{children}</>;
   }
 
   if (disabled) {
     logger.warn("FormoAnalytics is disabled");
-    return children;
+    return <>{children}</>;
   }
 
   return <InitializedAnalytics {...props} />;
 };
 
-const InitializedAnalytics = ({
+const InitializedAnalytics: FC<FormoAnalyticsProviderProps> = ({
   writeKey,
   options,
   children,
-}: FormoAnalyticsProviderProps): ReactNode => {
+}) => {
   const [sdk, setSdk] = useState<IFormoAnalytics>(defaultContext);
   const initializedStartedRef = useRef(false);
   initStorageManager(writeKey);

--- a/src/FormoAnalyticsProvider.tsx
+++ b/src/FormoAnalyticsProvider.tsx
@@ -51,7 +51,7 @@ const InitializedAnalytics: FC<FormoAnalyticsProviderProps> = ({
       initializedStartedRef.current = true;
 
       try {
-        const sdkInstance = await FormoAnalytics.init(writeKey!, options);
+        const sdkInstance = await FormoAnalytics.init(writeKey, options);
         setSdk(sdkInstance);
         logger.log("Successfully initialized :)");
       } catch (error) {

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -6,6 +6,7 @@ import {
   TransactionStatus,
 } from "./events";
 import { EIP1193Provider } from "./provider";
+import { ReactNode } from "react";
 
 export type Nullable<T> = T | null;
 // Decimal chain ID
@@ -123,5 +124,5 @@ export interface FormoAnalyticsProviderProps {
   writeKey: string;
   options?: Options;
   disabled?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
 }


### PR DESCRIPTION
Fixes:

```
./src/app/provider/AnalyticsProvider.tsx:16:6
Type error: 'FormoAnalyticsProvider' cannot be used as a JSX component.
  Its type '(props: FormoAnalyticsProviderProps) => string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | ... 6 more ... | undefined> | Element | null | undefined' is not a valid JSX element type.
    Type '(props: FormoAnalyticsProviderProps) => string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | ... 6 more ... | undefined> | Element | null | undefined' is not assignable to type '(props: any, deprecatedLegacyContext?: any) => ReactNode'.
      Type 'string | number | bigint | boolean | Iterable<ReactNode> | Promise<string | number | bigint | boolean | ReactPortal | Iterable<ReactNode> | ReactElement<...> | null | undefined> | Element | null | undefined' is not assignable to type 'ReactNode'.
        Type 'Promise<string | number | bigint | boolean | ReactPortal | Iterable<ReactNode> | ReactElement<unknown, string | JSXElementConstructor<any>> | null | undefined>' is not assignable to type 'ReactNode'.
          Type 'Promise<string | number | bigint | boolean | ReactPortal | Iterable<ReactNode> | ReactElement<unknown, string | JSXElementConstructor<any>> | null | undefined>' is not assignable to type 'Promise<AwaitedReactNode>'.
            Type 'string | number | bigint | boolean | ReactPortal | Iterable<ReactNode> | ReactElement<unknown, string | JSXElementConstructor<any>> | null | undefined' is not assignable to type 'AwaitedReactNode'.
              Type 'bigint' is not assignable to type 'AwaitedReactNode'.
```


the issue is exactly here:

```ts
export const FormoAnalyticsProvider = (props: FormoAnalyticsProviderProps): ReactNode => {
```

🔥 Why this is breaking:
You're typing the component as returning ReactNode, but React expects JSX components to return ReactElement, not just ReactNode — especially if you’re mixing with async behavior or certain render paths.

This typing:

```ts
(props: Props) => ReactNode
```

makes React treat it as a function, not a component, especially in Next.js and modern React setups.