### PR TITLE
P-1952 Handle race condition in wagmi and SDK initialization

### DIFF
--- a/src/wagmi/WagmiEventHandler.ts
+++ b/src/wagmi/WagmiEventHandler.ts
@@ -108,6 +108,11 @@ export class WagmiEventHandler {
 
     logger.info("WagmiEventHandler: Initializing Wagmi integration");
 
+    // Seed tracking state from current wagmi state if wallet is already connected.
+    // This handles the case where the SDK initializes after wagmi auto-reconnects,
+    // since subscribe() only fires on state transitions, not the current state.
+    this.initializeFromCurrentState();
+
     // Set up connection/disconnection/chain listeners
     this.setupConnectionListeners();
 
@@ -118,6 +123,35 @@ export class WagmiEventHandler {
     } else {
       logger.warn(
         "WagmiEventHandler: QueryClient not provided, signature and transaction events will not be tracked"
+      );
+    }
+  }
+
+  /**
+   * Seed trackingState if wagmi is already in a connected state.
+   * This ensures transaction/signature events have an address available
+   * even when the SDK initializes after wagmi auto-reconnects.
+   */
+  private initializeFromCurrentState(): void {
+    try {
+      const state = this.getState();
+      if (state.status === "connected") {
+        const address = this.getConnectedAddress(state);
+        const chainId = state.chainId;
+        if (address) {
+          this.trackingState.lastAddress = address;
+          this.trackingState.lastChainId = chainId;
+          this.trackingState.lastStatus = "connected";
+          logger.info(
+            "WagmiEventHandler: Wallet already connected, seeded tracking state",
+            { address, chainId }
+          );
+        }
+      }
+    } catch (error) {
+      logger.error(
+        "WagmiEventHandler: Error reading initial state:",
+        error
       );
     }
   }


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/getformo/sdk/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change limited to initialization logic; main risk is incorrect seeding if wagmi state access differs across wrappers, but it is guarded and logged.
> 
> **Overview**
> Fixes a wagmi/SDK initialization race by seeding `WagmiEventHandler` tracking state from the *current* wagmi connection state on startup, so analytics events have `address`/`chainId` even when wagmi auto-reconnects before subscriptions are attached.
> 
> Adds a new `initializeFromCurrentState()` call in the constructor with guarded state reads and error logging; no changes to the existing subscription-based listeners beyond this startup initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cdd85742bf7053fcca5d9e1cba239d4a321a22a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a race condition where wagmi auto-reconnects before the SDK's `subscribe()` listeners are attached, leaving `trackingState` without `address`/`chainId` for subsequent analytics events.

- Adds `initializeFromCurrentState()` in the `WagmiEventHandler` constructor that synchronously reads the current wagmi connection state and seeds `trackingState` if a wallet is already connected.
- The method is well-guarded: try/catch prevents constructor failure, null checks on address prevent partial state, and it runs before `setupConnectionListeners()` to avoid any ordering issues.
- No existing tests cover the new code path — the test mock defaults to a `disconnected` state at construction time, so the "already connected" branch is never exercised.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a defensive initialization guard with no changes to existing subscription logic.
- Score of 4 reflects a small, well-scoped change with proper error handling and guards. Deducted 1 point for the lack of unit test coverage on the new code path, which means the "already connected" initialization behavior is untested.
- test/wagmi/WagmiEventHandler.spec.ts needs new test cases for the initializeFromCurrentState behavior

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/wagmi/WagmiEventHandler.ts | Adds `initializeFromCurrentState()` method to seed tracking state from current wagmi connection on startup, fixing a race condition where wagmi auto-reconnects before SDK subscriptions are attached. Change is well-guarded with try/catch and null checks, but lacks unit test coverage for the new code path. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as App/Wagmi
    participant SDK as WagmiEventHandler
    participant State as wagmiConfig.getState()
    participant Track as trackingState

    Note over App,SDK: SDK initialization (constructor)
    App->>SDK: new WagmiEventHandler(formo, wagmiConfig)
    
    Note over SDK: NEW: initializeFromCurrentState()
    SDK->>State: getState()
    State-->>SDK: { status: "connected", chainId, connections }
    SDK->>SDK: getConnectedAddress(state)
    SDK->>Track: seed lastAddress, lastChainId, lastStatus

    Note over SDK: setupConnectionListeners()
    SDK->>App: wagmiConfig.subscribe(status)
    SDK->>App: wagmiConfig.subscribe(chainId)

    Note over App,Track: Later: transaction/signature events
    App->>SDK: mutation event (sendTransaction)
    SDK->>Track: read lastAddress, lastChainId
    Note over SDK: address/chainId available ✓
```

<sub>Last reviewed commit: 9cdd857</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Review and address all automated code review comments (like Copilot suggestions) before merging PRs,... ([source](https://app.greptile.com/review/custom-context?memory=4b2ee25e-0601-426f-8ee2-89c776b11fc3))

<!-- /greptile_comment -->