### PR TITLE
Replace cookie-based URL tracking with in-memory state for SPA

### DIFF
--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -3,7 +3,6 @@ import {
   EVENTS_API_HOST,
   EventType,
   LOCAL_ANONYMOUS_ID_KEY,
-  SESSION_CURRENT_URL_KEY,
   SESSION_USER_ID_KEY,
   CONSENT_OPT_OUT_KEY,
   TEventType,
@@ -144,6 +143,9 @@ export class FormoAnalytics implements IFormoAnalytics {
   /** Instance-level flag so multiple SDK instances don't interfere. */
   private crossSubdomainCookies: boolean;
 
+  /** In-memory URL used to deduplicate SPA pageview events. */
+  private _currentUrl: string = "";
+
   config: Config;
   currentChainId?: ChainID;
   currentAddress?: Address;
@@ -243,6 +245,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       this.solanaManager = new SolanaManager(this, options.solana);
     }
 
+    this._currentUrl = window.location.href;
     this.trackPageHit();
     this.trackPageHits();
   }
@@ -1660,10 +1663,8 @@ export class FormoAnalytics implements IFormoAnalytics {
   }
 
   private async onLocationChange(): Promise<void> {
-    const currentUrl = cookie().get(SESSION_CURRENT_URL_KEY);
-
-    if (currentUrl !== window.location.href) {
-      cookie().set(SESSION_CURRENT_URL_KEY, window.location.href);
+    if (this._currentUrl !== window.location.href) {
+      this._currentUrl = window.location.href;
       this.trackPageHit();
     }
   }

--- a/src/constants/base.ts
+++ b/src/constants/base.ts
@@ -1,7 +1,6 @@
 export const SESSION_TRAFFIC_SOURCE_KEY = "traffic-source";
 // SESSION_WALLET_DETECTED_KEY and SESSION_WALLET_IDENTIFIED_KEY
 // are now defined in src/session/index.ts
-export const SESSION_CURRENT_URL_KEY = "analytics-current-url";
 export const SESSION_USER_ID_KEY = "user-id";
 
 export const LOCAL_ANONYMOUS_ID_KEY = "anonymous-id";

--- a/test/constants/base.spec.ts
+++ b/test/constants/base.spec.ts
@@ -2,7 +2,6 @@ import { describe, it } from "mocha";
 import { expect } from "chai";
 import {
   SESSION_TRAFFIC_SOURCE_KEY,
-  SESSION_CURRENT_URL_KEY,
   SESSION_USER_ID_KEY,
   LOCAL_ANONYMOUS_ID_KEY,
   CONSENT_OPT_OUT_KEY,
@@ -24,10 +23,6 @@ describe("Constants - Backward Compatibility", () => {
   describe("Storage key values must not change", () => {
     it("SESSION_TRAFFIC_SOURCE_KEY should have stable value", () => {
       expect(SESSION_TRAFFIC_SOURCE_KEY).to.equal("traffic-source");
-    });
-
-    it("SESSION_CURRENT_URL_KEY should have stable value", () => {
-      expect(SESSION_CURRENT_URL_KEY).to.equal("analytics-current-url");
     });
 
     it("SESSION_USER_ID_KEY should have stable value", () => {


### PR DESCRIPTION
## Summary
Refactored the URL tracking mechanism in FormoAnalytics to use in-memory state instead of session cookies. This improves performance and simplifies the deduplication logic for SPA pageview events.

## Key Changes
- Replaced `SESSION_CURRENT_URL_KEY` cookie-based storage with a private `_currentUrl` instance variable
- Removed the `SESSION_CURRENT_URL_KEY` constant from `src/constants/base.ts` and its imports
- Updated `onLocationChange()` method to compare and update the in-memory URL instead of reading/writing to cookies
- Initialize `_currentUrl` with `window.location.href` during SDK initialization
- Removed associated test case for the deprecated constant

## Implementation Details
- The in-memory approach is sufficient since URL tracking is instance-specific and doesn't require persistence across page reloads
- This eliminates unnecessary cookie I/O operations while maintaining the same deduplication behavior for detecting actual page navigation in SPAs
- Each SDK instance maintains its own `_currentUrl` state, preventing interference between multiple instances

https://claude.ai/code/session_01Gi7ArkPEHAhDCmkUTNhQBs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/getformo/sdk/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
