### PR TITLE
P-2178 Fix orphaned instance page events

### DIFF
--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -761,7 +761,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       const validAddress = validateAddress(address);
       if (validAddress) {
         this.currentAddress = validAddress;
-        this.persistCurrentWallet();
+        this.persistActiveWallet();
       } else {
         logger.warn?.("Invalid address provided to identify:", address);
         return;
@@ -2172,7 +2172,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
 
     const effectiveChainId = chainId ?? this._evmChainId ?? undefined;
-    this.backfillSessionAddress(validAddress, effectiveChainId);
+    this.backfillActiveWallet(validAddress, effectiveChainId);
 
     const basePayload = {
       chainId: effectiveChainId,
@@ -2215,7 +2215,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
 
     const chainId = this._evmChainId || (await this.getCurrentChainId(provider));
-    this.backfillSessionAddress(validAddress, chainId);
+    this.backfillActiveWallet(validAddress, chainId);
 
     return {
       chainId,
@@ -2234,7 +2234,7 @@ export class FormoAnalytics implements IFormoAnalytics {
    * social-login wrappers). If `accountsChanged` later fires it overwrites this
    * value in the normal way; existing connections are never clobbered.
    */
-  private backfillSessionAddress(address: Address, chainId?: ChainID): void {
+  private backfillActiveWallet(address: Address, chainId?: ChainID): void {
     if (this._evmAddress) return;
     this.setChainState('evm', { address, chainId });
   }
@@ -2451,7 +2451,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       if (state.address || state.chainId) {
         this.currentAddress = state.address;
         this.currentChainId = state.chainId;
-        this.persistCurrentWallet();
+        this.persistActiveWallet();
         return;
       }
     }
@@ -2462,12 +2462,12 @@ export class FormoAnalytics implements IFormoAnalytics {
       this.currentAddress = otherState.address;
       this.currentChainId = otherState.chainId;
       this._activeNamespace = other;
-      this.persistCurrentWallet();
+      this.persistActiveWallet();
       return;
     }
     this.currentAddress = undefined;
     this.currentChainId = undefined;
-    this.persistCurrentWallet();
+    this.persistActiveWallet();
   }
 
   /**
@@ -2477,7 +2477,7 @@ export class FormoAnalytics implements IFormoAnalytics {
    * reconnection during which track()/page() events would otherwise ship
    * with an empty address.
    */
-  private persistCurrentWallet(): void {
+  private persistActiveWallet(): void {
     try {
       if (this.currentAddress) {
         const value = JSON.stringify({

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -2111,8 +2111,11 @@ export class FormoAnalytics implements IFormoAnalytics {
       throw new Error(`Invalid address in signature payload: ${rawAddress}`);
     }
 
+    const effectiveChainId = chainId ?? this._evmChainId ?? undefined;
+    this.backfillEvmAddressIfEmpty(validAddress, effectiveChainId);
+
     const basePayload = {
-      chainId: chainId ?? this._evmChainId ?? undefined,
+      chainId: effectiveChainId,
       address: validAddress,
     };
 
@@ -2151,13 +2154,29 @@ export class FormoAnalytics implements IFormoAnalytics {
       throw new Error(`Invalid address in transaction payload: ${from}`);
     }
 
+    const chainId = this._evmChainId || (await this.getCurrentChainId(provider));
+    this.backfillEvmAddressIfEmpty(validAddress, chainId);
+
     return {
-      chainId: this._evmChainId || (await this.getCurrentChainId(provider)),
+      chainId,
       data,
       address: validAddress,
       to,
       value,
     };
+  }
+
+  /**
+   * Persist an EVM address discovered through autocapture (signature / transaction)
+   * as the current EVM address when none is currently set. This lets subsequent
+   * track()/page() calls carry the address even when the underlying wallet never
+   * fires an EIP-1193 `accountsChanged` event (embedded wallets, smart accounts,
+   * social-login wrappers). If `accountsChanged` later fires it overwrites this
+   * value in the normal way; existing connections are never clobbered.
+   */
+  private backfillEvmAddressIfEmpty(address: Address, chainId?: ChainID): void {
+    if (this._evmAddress) return;
+    this.setChainState('evm', { address, chainId });
   }
 
   /**

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -4,8 +4,8 @@ import {
   EventType,
   LOCAL_ANONYMOUS_ID_KEY,
   SESSION_USER_ID_KEY,
-  CURRENT_WALLET_KEY,
-  CURRENT_WALLET_TTL_MS,
+  ACTIVE_WALLET_KEY,
+  ACTIVE_WALLET_TTL_MS,
   CONSENT_OPT_OUT_KEY,
   TEventType,
 } from "./constants";
@@ -257,7 +257,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     // Seed currentAddress/currentChainId from the persisted snapshot before
     // the first page hit queues so reload-time track()/page() carry the
     // wallet even before wagmi/EIP-1193 reconnection completes.
-    this.getSessionAddress();
+    this.loadActiveWallet();
 
     this.trackPageHit();
     this.trackPageHits();
@@ -318,7 +318,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     cookie().remove(SESSION_USER_ID_KEY);
     cookie().remove(SESSION_WALLET_DETECTED_KEY);
     cookie().remove(SESSION_WALLET_IDENTIFIED_KEY);
-    cookie().remove(CURRENT_WALLET_KEY);
+    cookie().remove(ACTIVE_WALLET_KEY);
   }
 
   /**
@@ -2485,13 +2485,13 @@ export class FormoAnalytics implements IFormoAnalytics {
           ...(this.currentChainId !== undefined && { chainId: this.currentChainId }),
         });
         const domain = getIdentityCookieDomain(this.crossSubdomainCookies);
-        cookie().set(CURRENT_WALLET_KEY, value, {
+        cookie().set(ACTIVE_WALLET_KEY, value, {
           path: "/",
-          expires: new Date(Date.now() + CURRENT_WALLET_TTL_MS).toUTCString(),
+          expires: new Date(Date.now() + ACTIVE_WALLET_TTL_MS).toUTCString(),
           ...(domain ? { domain } : {}),
         });
       } else {
-        cookie().remove(CURRENT_WALLET_KEY);
+        cookie().remove(ACTIVE_WALLET_KEY);
       }
     } catch (err) {
       logger.warn("Failed to persist current wallet snapshot", err);
@@ -2502,16 +2502,16 @@ export class FormoAnalytics implements IFormoAnalytics {
    * Seed `currentAddress`/`currentChainId` from the persisted snapshot, if
    * any. Called once during construction before the first page hit fires.
    */
-  private getSessionAddress(): void {
+  private loadActiveWallet(): void {
     try {
-      const raw = cookie().get(CURRENT_WALLET_KEY) as string | undefined;
+      const raw = cookie().get(ACTIVE_WALLET_KEY) as string | undefined;
       if (!raw) return;
       const parsed = JSON.parse(raw) as { address?: string; chainId?: ChainID };
       if (!parsed?.address) return;
       const namespace = isSolanaChainId(parsed.chainId) ? "solana" : "evm";
       const validated = validateAddress(parsed.address, parsed.chainId);
       if (!validated) {
-        cookie().remove(CURRENT_WALLET_KEY);
+        cookie().remove(ACTIVE_WALLET_KEY);
         return;
       }
       const ns = this._chainState[namespace];
@@ -2522,7 +2522,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       this.currentChainId = parsed.chainId;
     } catch (err) {
       logger.warn("Failed to restore persisted wallet snapshot", err);
-      cookie().remove(CURRENT_WALLET_KEY);
+      cookie().remove(ACTIVE_WALLET_KEY);
     }
   }
 

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -5,6 +5,7 @@ import {
   LOCAL_ANONYMOUS_ID_KEY,
   SESSION_USER_ID_KEY,
   CURRENT_WALLET_KEY,
+  CURRENT_WALLET_TTL_MS,
   CONSENT_OPT_OUT_KEY,
   TEventType,
 } from "./constants";
@@ -256,7 +257,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     // Seed currentAddress/currentChainId from the persisted snapshot before
     // the first page hit queues so reload-time track()/page() carry the
     // wallet even before wagmi/EIP-1193 reconnection completes.
-    this.restorePersistedWallet();
+    this.getSessionAddress();
 
     this.trackPageHit();
     this.trackPageHits();
@@ -1699,34 +1700,47 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
   }
 
-  private async trackPageHits(): Promise<void> {
-    // Capture `this`-bound disposed flag inside the wrapper closures so a
-    // cleaned-up instance still chains to the prior implementation but stops
-    // dispatching synthetic `locationchange` events. The wrappers themselves
-    // cannot be unwound (a later instance may have wrapped on top of us), but
-    // making them inert is enough to silence the orphan.
-    const oldPushState = history.pushState;
-    history.pushState = (...args) => {
-      const ret = oldPushState.apply(history, args as Parameters<typeof history.pushState>);
-      if (!this._pageHooksDisposed) {
-        window.dispatchEvent(new window.Event("locationchange"));
-      }
-      return ret;
-    };
-
-    const oldReplaceState = history.replaceState;
-    history.replaceState = (...args) => {
-      const ret = oldReplaceState.apply(history, args as Parameters<typeof history.replaceState>);
-      if (!this._pageHooksDisposed) {
-        window.dispatchEvent(new window.Event("locationchange"));
-      }
-      return ret;
-    };
+  private trackPageHits(): void {
+    // Install a single, instance-agnostic wrapper around history.pushState /
+    // replaceState so concurrent SDK instances (React Strict Mode, HMR) don't
+    // each stack their own wrapper — which would dispatch N synthetic events
+    // per navigation and produce O(N^2) onLocationChange calls. The wrapper
+    // dispatches once; per-instance bookkeeping is done by per-instance
+    // listeners that each register/unregister themselves.
+    FormoAnalytics.installHistoryHooksOnce();
 
     this._onPopStateListener = () => this.onLocationChange();
     this._onLocationChangeListener = () => this.onLocationChange();
     window.addEventListener("popstate", this._onPopStateListener);
     window.addEventListener("locationchange", this._onLocationChangeListener);
+  }
+
+  /**
+   * Wrap history.pushState / replaceState exactly once per `history` object,
+   * regardless of how many SDK instances are constructed. Uses a Symbol
+   * marker so we recognize our own wrapper across module reloads in HMR.
+   */
+  private static installHistoryHooksOnce(): void {
+    if (typeof history === "undefined" || typeof window === "undefined") return;
+    const marker = Symbol.for("formo.historyWrapped");
+    if ((history as unknown as Record<symbol, boolean>)[marker]) return;
+    (history as unknown as Record<symbol, boolean>)[marker] = true;
+
+    const dispatch = () => window.dispatchEvent(new window.Event("locationchange"));
+
+    const oldPushState = history.pushState;
+    history.pushState = function pushState(...args: Parameters<typeof history.pushState>) {
+      const ret = oldPushState.apply(this, args);
+      dispatch();
+      return ret;
+    };
+
+    const oldReplaceState = history.replaceState;
+    history.replaceState = function replaceState(...args: Parameters<typeof history.replaceState>) {
+      const ret = oldReplaceState.apply(this, args);
+      dispatch();
+      return ret;
+    };
   }
 
   private async trackPageHit(
@@ -2158,7 +2172,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
 
     const effectiveChainId = chainId ?? this._evmChainId ?? undefined;
-    this.backfillEvmAddressIfEmpty(validAddress, effectiveChainId);
+    this.backfillSessionAddress(validAddress, effectiveChainId);
 
     const basePayload = {
       chainId: effectiveChainId,
@@ -2201,7 +2215,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
 
     const chainId = this._evmChainId || (await this.getCurrentChainId(provider));
-    this.backfillEvmAddressIfEmpty(validAddress, chainId);
+    this.backfillSessionAddress(validAddress, chainId);
 
     return {
       chainId,
@@ -2220,7 +2234,7 @@ export class FormoAnalytics implements IFormoAnalytics {
    * social-login wrappers). If `accountsChanged` later fires it overwrites this
    * value in the normal way; existing connections are never clobbered.
    */
-  private backfillEvmAddressIfEmpty(address: Address, chainId?: ChainID): void {
+  private backfillSessionAddress(address: Address, chainId?: ChainID): void {
     if (this._evmAddress) return;
     this.setChainState('evm', { address, chainId });
   }
@@ -2473,8 +2487,7 @@ export class FormoAnalytics implements IFormoAnalytics {
         const domain = getIdentityCookieDomain(this.crossSubdomainCookies);
         cookie().set(CURRENT_WALLET_KEY, value, {
           path: "/",
-          // Mirror the SESSION_WALLET_* cookies in src/session/index.ts.
-          expires: new Date(Date.now() + 86400 * 1000).toUTCString(),
+          expires: new Date(Date.now() + CURRENT_WALLET_TTL_MS).toUTCString(),
           ...(domain ? { domain } : {}),
         });
       } else {
@@ -2489,7 +2502,7 @@ export class FormoAnalytics implements IFormoAnalytics {
    * Seed `currentAddress`/`currentChainId` from the persisted snapshot, if
    * any. Called once during construction before the first page hit fires.
    */
-  private restorePersistedWallet(): void {
+  private getSessionAddress(): void {
     try {
       const raw = cookie().get(CURRENT_WALLET_KEY) as string | undefined;
       if (!raw) return;

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -4,6 +4,7 @@ import {
   EventType,
   LOCAL_ANONYMOUS_ID_KEY,
   SESSION_USER_ID_KEY,
+  CURRENT_WALLET_KEY,
   CONSENT_OPT_OUT_KEY,
   TEventType,
 } from "./constants";
@@ -146,6 +147,11 @@ export class FormoAnalytics implements IFormoAnalytics {
   /** In-memory URL used to deduplicate SPA pageview events. */
   private _currentUrl: string = "";
 
+  /** Page-hit hooks installed in trackPageHits() so cleanup() can undo them. */
+  private _onPopStateListener?: (e: Event) => void;
+  private _onLocationChangeListener?: (e: Event) => void;
+  private _pageHooksDisposed = false;
+
   config: Config;
   currentChainId?: ChainID;
   currentAddress?: Address;
@@ -246,6 +252,12 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
 
     this._currentUrl = window.location.href;
+
+    // Seed currentAddress/currentChainId from the persisted snapshot before
+    // the first page hit queues so reload-time track()/page() carry the
+    // wallet even before wagmi/EIP-1193 reconnection completes.
+    this.restorePersistedWallet();
+
     this.trackPageHit();
     this.trackPageHits();
   }
@@ -305,6 +317,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     cookie().remove(SESSION_USER_ID_KEY);
     cookie().remove(SESSION_WALLET_DETECTED_KEY);
     cookie().remove(SESSION_WALLET_IDENTIFIED_KEY);
+    cookie().remove(CURRENT_WALLET_KEY);
   }
 
   /**
@@ -331,6 +344,22 @@ export class FormoAnalytics implements IFormoAnalytics {
     if (!this.isWagmiMode) {
       for (const provider of Array.from(this._trackedProviders)) {
         this.untrackProvider(provider);
+      }
+    }
+
+    // Tear down page-hit hooks: remove window listeners and silence the
+    // history.pushState/replaceState wrappers so an orphaned instance (e.g.
+    // from a re-mount in React Strict Mode / HMR) stops emitting page events
+    // with stale state.
+    this._pageHooksDisposed = true;
+    if (typeof window !== "undefined") {
+      if (this._onPopStateListener) {
+        window.removeEventListener("popstate", this._onPopStateListener);
+        this._onPopStateListener = undefined;
+      }
+      if (this._onLocationChangeListener) {
+        window.removeEventListener("locationchange", this._onLocationChangeListener);
+        this._onLocationChangeListener = undefined;
       }
     }
 
@@ -731,6 +760,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       const validAddress = validateAddress(address);
       if (validAddress) {
         this.currentAddress = validAddress;
+        this.persistCurrentWallet();
       } else {
         logger.warn?.("Invalid address provided to identify:", address);
         return;
@@ -1670,22 +1700,33 @@ export class FormoAnalytics implements IFormoAnalytics {
   }
 
   private async trackPageHits(): Promise<void> {
+    // Capture `this`-bound disposed flag inside the wrapper closures so a
+    // cleaned-up instance still chains to the prior implementation but stops
+    // dispatching synthetic `locationchange` events. The wrappers themselves
+    // cannot be unwound (a later instance may have wrapped on top of us), but
+    // making them inert is enough to silence the orphan.
     const oldPushState = history.pushState;
-    history.pushState = function pushState(...args) {
-      const ret = oldPushState.apply(this, args);
-      window.dispatchEvent(new window.Event("locationchange"));
+    history.pushState = (...args) => {
+      const ret = oldPushState.apply(history, args as Parameters<typeof history.pushState>);
+      if (!this._pageHooksDisposed) {
+        window.dispatchEvent(new window.Event("locationchange"));
+      }
       return ret;
     };
 
     const oldReplaceState = history.replaceState;
-    history.replaceState = function replaceState(...args) {
-      const ret = oldReplaceState.apply(this, args);
-      window.dispatchEvent(new window.Event("locationchange"));
+    history.replaceState = (...args) => {
+      const ret = oldReplaceState.apply(history, args as Parameters<typeof history.replaceState>);
+      if (!this._pageHooksDisposed) {
+        window.dispatchEvent(new window.Event("locationchange"));
+      }
       return ret;
     };
 
-    window.addEventListener("popstate", () => this.onLocationChange());
-    window.addEventListener("locationchange", () => this.onLocationChange());
+    this._onPopStateListener = () => this.onLocationChange();
+    this._onLocationChangeListener = () => this.onLocationChange();
+    window.addEventListener("popstate", this._onPopStateListener);
+    window.addEventListener("locationchange", this._onLocationChangeListener);
   }
 
   private async trackPageHit(
@@ -1703,6 +1744,11 @@ export class FormoAnalytics implements IFormoAnalytics {
     }
 
     setTimeout(() => {
+      // Drop in-flight page hits from an SDK instance that was torn down
+      // between scheduling and firing (e.g. provider remount in React Strict
+      // Mode / HMR). Otherwise the orphan instance would queue a page event
+      // here with its stale, never-populated `currentAddress`.
+      if (this._pageHooksDisposed) return;
       (async () => {
         try {
           await this.trackEvent(
@@ -2391,6 +2437,7 @@ export class FormoAnalytics implements IFormoAnalytics {
       if (state.address || state.chainId) {
         this.currentAddress = state.address;
         this.currentChainId = state.chainId;
+        this.persistCurrentWallet();
         return;
       }
     }
@@ -2401,10 +2448,69 @@ export class FormoAnalytics implements IFormoAnalytics {
       this.currentAddress = otherState.address;
       this.currentChainId = otherState.chainId;
       this._activeNamespace = other;
+      this.persistCurrentWallet();
       return;
     }
     this.currentAddress = undefined;
     this.currentChainId = undefined;
+    this.persistCurrentWallet();
+  }
+
+  /**
+   * Persist (or clear) the current wallet snapshot in a cookie so that the
+   * SDK can repopulate `currentAddress`/`currentChainId` at init on the next
+   * page load — closing the gap between page-show and wagmi/EIP-1193
+   * reconnection during which track()/page() events would otherwise ship
+   * with an empty address.
+   */
+  private persistCurrentWallet(): void {
+    try {
+      if (this.currentAddress) {
+        const value = JSON.stringify({
+          address: this.currentAddress,
+          ...(this.currentChainId !== undefined && { chainId: this.currentChainId }),
+        });
+        const domain = getIdentityCookieDomain(this.crossSubdomainCookies);
+        cookie().set(CURRENT_WALLET_KEY, value, {
+          path: "/",
+          // Mirror the SESSION_WALLET_* cookies in src/session/index.ts.
+          expires: new Date(Date.now() + 86400 * 1000).toUTCString(),
+          ...(domain ? { domain } : {}),
+        });
+      } else {
+        cookie().remove(CURRENT_WALLET_KEY);
+      }
+    } catch (err) {
+      logger.warn("Failed to persist current wallet snapshot", err);
+    }
+  }
+
+  /**
+   * Seed `currentAddress`/`currentChainId` from the persisted snapshot, if
+   * any. Called once during construction before the first page hit fires.
+   */
+  private restorePersistedWallet(): void {
+    try {
+      const raw = cookie().get(CURRENT_WALLET_KEY) as string | undefined;
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as { address?: string; chainId?: ChainID };
+      if (!parsed?.address) return;
+      const namespace = isSolanaChainId(parsed.chainId) ? "solana" : "evm";
+      const validated = validateAddress(parsed.address, parsed.chainId);
+      if (!validated) {
+        cookie().remove(CURRENT_WALLET_KEY);
+        return;
+      }
+      const ns = this._chainState[namespace];
+      ns.address = validated;
+      if (parsed.chainId !== undefined) ns.chainId = parsed.chainId;
+      this._activeNamespace = namespace;
+      this.currentAddress = validated;
+      this.currentChainId = parsed.chainId;
+    } catch (err) {
+      logger.warn("Failed to restore persisted wallet snapshot", err);
+      cookie().remove(CURRENT_WALLET_KEY);
+    }
   }
 
   /**

--- a/src/constants/base.ts
+++ b/src/constants/base.ts
@@ -4,15 +4,15 @@ export const SESSION_TRAFFIC_SOURCE_KEY = "traffic-source";
 export const SESSION_USER_ID_KEY = "user-id";
 
 /**
- * Persisted snapshot of the currently-active EVM wallet (address + chainId).
- * Lets the SDK seed `currentAddress`/`currentChainId` at init so the first
- * page hit after a reload carries the address, without having to wait for
- * wagmi/EIP-1193 reconnection to fire.
+ * Persisted snapshot of the currently-active EVM/Solana wallet
+ * (address + chainId). Lets the SDK seed `currentAddress`/`currentChainId`
+ * at init so the first page hit after a reload carries the address, without
+ * having to wait for wagmi/EIP-1193 reconnection to fire.
  */
-export const CURRENT_WALLET_KEY = "current-wallet";
+export const ACTIVE_WALLET_KEY = "active-wallet";
 
-/** TTL for the persisted wallet snapshot cookie. */
-export const CURRENT_WALLET_TTL_MS = 24 * 60 * 60 * 1000;
+/** TTL for the persisted active-wallet snapshot cookie. */
+export const ACTIVE_WALLET_TTL_MS = 24 * 60 * 60 * 1000;
 
 export const LOCAL_ANONYMOUS_ID_KEY = "anonymous-id";
 

--- a/src/constants/base.ts
+++ b/src/constants/base.ts
@@ -3,6 +3,14 @@ export const SESSION_TRAFFIC_SOURCE_KEY = "traffic-source";
 // are now defined in src/session/index.ts
 export const SESSION_USER_ID_KEY = "user-id";
 
+/**
+ * Persisted snapshot of the currently-active EVM wallet (address + chainId).
+ * Lets the SDK seed `currentAddress`/`currentChainId` at init so the first
+ * page hit after a reload carries the address, without having to wait for
+ * wagmi/EIP-1193 reconnection to fire.
+ */
+export const CURRENT_WALLET_KEY = "current-wallet";
+
 export const LOCAL_ANONYMOUS_ID_KEY = "anonymous-id";
 
 // Consent management keys

--- a/src/constants/base.ts
+++ b/src/constants/base.ts
@@ -11,6 +11,9 @@ export const SESSION_USER_ID_KEY = "user-id";
  */
 export const CURRENT_WALLET_KEY = "current-wallet";
 
+/** TTL for the persisted wallet snapshot cookie. */
+export const CURRENT_WALLET_TTL_MS = 24 * 60 * 60 * 1000;
+
 export const LOCAL_ANONYMOUS_ID_KEY = "anonymous-id";
 
 // Consent management keys

--- a/test/addressBackfill.spec.ts
+++ b/test/addressBackfill.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { JSDOM } from "jsdom";
+import { FormoAnalytics } from "../src/FormoAnalytics";
+import { initStorageManager } from "../src/storage";
+
+/**
+ * Regression: track()/page() must carry an address even when the wallet
+ * never fires EIP-1193 `accountsChanged` (embedded / smart / social-login
+ * wallets). The autocapture signature & transaction payload builders now
+ * backfill `currentAddress` from the `from` they extract, so subsequent
+ * track/page events pick it up.
+ */
+describe("Address backfill from autocapture", () => {
+  let sandbox: sinon.SinonSandbox;
+  let jsdom: JSDOM;
+  let formo: FormoAnalytics;
+
+  const ADDRESS_LOWER = "0x51377e9b985bb90b7c091b9a7d30c93d4c9c1cef";
+  const ADDRESS_CHECKSUMMED = "0x51377e9B985Bb90B7c091B9a7d30C93d4c9c1CEf";
+  const CHAIN_ID = 1;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    jsdom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>", {
+      url: "https://example.com",
+    });
+    Object.defineProperty(global, "window", {
+      value: jsdom.window, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "document", {
+      value: jsdom.window.document, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "location", {
+      value: jsdom.window.location, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "globalThis", {
+      value: jsdom.window, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "navigator", {
+      value: jsdom.window.navigator, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "localStorage", {
+      value: jsdom.window.localStorage, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "sessionStorage", {
+      value: jsdom.window.sessionStorage, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "crypto", {
+      value: { randomUUID: () => "mock-uuid-1234" },
+      writable: true, configurable: true,
+    });
+
+    initStorageManager("test-write-key");
+
+    const mockWagmiConfig = {
+      subscribe: sandbox.stub().returns(() => {}),
+      state: { status: "disconnected", connections: new Map(), current: undefined, chainId: undefined },
+      _internal: { store: { subscribe: sandbox.stub().returns(() => {}) } },
+    };
+    const mockQueryClient = {
+      getMutationCache: () => ({ subscribe: sandbox.stub().returns(() => {}) }),
+      getQueryCache: () => ({ subscribe: sandbox.stub().returns(() => {}) }),
+    };
+
+    formo = await FormoAnalytics.init("test-write-key", {
+      wagmi: {
+        config: mockWagmiConfig as any,
+        queryClient: mockQueryClient as any,
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).location;
+    delete (global as any).globalThis;
+    delete (global as any).navigator;
+    delete (global as any).localStorage;
+    delete (global as any).sessionStorage;
+    delete (global as any).crypto;
+    if (jsdom) jsdom.window.close();
+  });
+
+  it("buildTransactionEventPayload backfills currentAddress when none is set", async () => {
+    expect(formo.currentAddress).to.be.undefined;
+
+    const mockProvider = {
+      request: sandbox.stub().withArgs(sinon.match({ method: "eth_chainId" })).resolves(`0x${CHAIN_ID.toString(16)}`),
+    } as any;
+
+    const payload = await (formo as any).buildTransactionEventPayload(
+      [{ from: ADDRESS_LOWER, to: "0xabc", value: "0x0", data: "0x" }],
+      mockProvider
+    );
+
+    expect(payload.address).to.equal(ADDRESS_CHECKSUMMED);
+    expect(payload.chainId).to.equal(CHAIN_ID);
+    // Backfill: subsequent track()/page() can now read this.
+    expect(formo.currentAddress).to.equal(ADDRESS_CHECKSUMMED);
+    expect(formo.currentChainId).to.equal(CHAIN_ID);
+  });
+
+  it("buildSignatureEventPayload backfills currentAddress when none is set", () => {
+    expect(formo.currentAddress).to.be.undefined;
+
+    const payload = (formo as any).buildSignatureEventPayload(
+      "eth_signTypedData_v4",
+      [ADDRESS_LOWER, '{"foo":"bar"}'],
+      undefined,
+      CHAIN_ID
+    );
+
+    expect(payload.address).to.equal(ADDRESS_CHECKSUMMED);
+    expect(formo.currentAddress).to.equal(ADDRESS_CHECKSUMMED);
+    expect(formo.currentChainId).to.equal(CHAIN_ID);
+  });
+
+  it("track() carries the backfilled address after an autocapture transaction", async () => {
+    const addEventStub = sandbox.stub((formo as any).eventManager, "addEvent").resolves();
+
+    const mockProvider = {
+      request: sandbox.stub().withArgs(sinon.match({ method: "eth_chainId" })).resolves(`0x${CHAIN_ID.toString(16)}`),
+    } as any;
+
+    // Simulate autocapture transaction having been processed; no
+    // accountsChanged was ever dispatched, so currentAddress starts empty.
+    expect(formo.currentAddress).to.be.undefined;
+    await (formo as any).buildTransactionEventPayload(
+      [{ from: ADDRESS_LOWER, to: "0xabc", value: "0x0", data: "0x" }],
+      mockProvider
+    );
+
+    // Merchant app fires its custom analytics event after the wallet action.
+    await formo.track("Deposit Success", { value_usd: 508 });
+
+    expect(addEventStub.calledOnce).to.be.true;
+    const [, addressArg] = addEventStub.firstCall.args;
+    expect(addressArg).to.equal(ADDRESS_CHECKSUMMED);
+  });
+
+  it("does not clobber an existing connected address", async () => {
+    const OTHER_ADDRESS = "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e";
+    await formo.connect({ chainId: CHAIN_ID, address: OTHER_ADDRESS });
+    expect(formo.currentAddress).to.equal(OTHER_ADDRESS);
+
+    const mockProvider = {
+      request: sandbox.stub().withArgs(sinon.match({ method: "eth_chainId" })).resolves(`0x${CHAIN_ID.toString(16)}`),
+    } as any;
+
+    await (formo as any).buildTransactionEventPayload(
+      [{ from: ADDRESS_LOWER, to: "0xabc", value: "0x0", data: "0x" }],
+      mockProvider
+    );
+
+    // Backfill must not overwrite the connected address.
+    expect(formo.currentAddress).to.equal(OTHER_ADDRESS);
+  });
+});

--- a/test/addressPersistence.spec.ts
+++ b/test/addressPersistence.spec.ts
@@ -4,7 +4,7 @@ import * as sinon from "sinon";
 import { JSDOM } from "jsdom";
 import { FormoAnalytics } from "../src/FormoAnalytics";
 import { initStorageManager, cookie } from "../src/storage";
-import { CURRENT_WALLET_KEY } from "../src/constants";
+import { ACTIVE_WALLET_KEY } from "../src/constants";
 
 /**
  * Regressions for two issues that produced page events with empty `address`:
@@ -62,11 +62,11 @@ describe("Address persistence and cleanup", () => {
     Object.defineProperty(global, "history", { value: jsdom.window.history, writable: true, configurable: true });
 
     initStorageManager("test-write-key");
-    cookie().remove(CURRENT_WALLET_KEY);
+    cookie().remove(ACTIVE_WALLET_KEY);
   });
 
   afterEach(() => {
-    cookie().remove(CURRENT_WALLET_KEY);
+    cookie().remove(ACTIVE_WALLET_KEY);
     sandbox.restore();
     delete (global as any).window;
     delete (global as any).document;
@@ -89,7 +89,7 @@ describe("Address persistence and cleanup", () => {
       sandbox.stub(a as any, "trackEvent").resolves();
       await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
 
-      expect(cookie().get(CURRENT_WALLET_KEY)).to.be.a("string");
+      expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.a("string");
       a.cleanup();
 
       // Simulate a reload by creating a fresh instance.
@@ -133,10 +133,10 @@ describe("Address persistence and cleanup", () => {
       });
       sandbox.stub(a as any, "trackEvent").resolves();
       await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
-      expect(cookie().get(CURRENT_WALLET_KEY)).to.be.a("string");
+      expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.a("string");
 
       await a.disconnect({ chainId: CHAIN_ID, address: ADDRESS });
-      expect(cookie().get(CURRENT_WALLET_KEY)).to.satisfy(
+      expect(cookie().get(ACTIVE_WALLET_KEY)).to.satisfy(
         (v: any) => v === undefined || v === null || v === ""
       );
       a.cleanup();
@@ -151,7 +151,7 @@ describe("Address persistence and cleanup", () => {
       await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
 
       a.reset();
-      expect(cookie().get(CURRENT_WALLET_KEY)).to.satisfy(
+      expect(cookie().get(ACTIVE_WALLET_KEY)).to.satisfy(
         (v: any) => v === undefined || v === null || v === ""
       );
       a.cleanup();
@@ -231,13 +231,13 @@ describe("Address persistence and cleanup", () => {
     });
 
     it("ignores a corrupt persisted snapshot and clears the cookie", async () => {
-      cookie().set(CURRENT_WALLET_KEY, "not-json{");
+      cookie().set(ACTIVE_WALLET_KEY, "not-json{");
       const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
       const a = await FormoAnalytics.init("test-write-key", {
         wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
       });
       expect(a.currentAddress).to.be.undefined;
-      expect(cookie().get(CURRENT_WALLET_KEY)).to.satisfy(
+      expect(cookie().get(ACTIVE_WALLET_KEY)).to.satisfy(
         (v: any) => v === undefined || v === null || v === ""
       );
       a.cleanup();
@@ -245,7 +245,7 @@ describe("Address persistence and cleanup", () => {
 
     it("does not seed from a persisted invalid address", async () => {
       cookie().set(
-        CURRENT_WALLET_KEY,
+        ACTIVE_WALLET_KEY,
         JSON.stringify({ address: "0xnot-an-address", chainId: CHAIN_ID })
       );
       const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
@@ -265,7 +265,7 @@ describe("Address persistence and cleanup", () => {
       await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
       await a.connect({ chainId: CHAIN_ID, address: OTHER_ADDRESS });
 
-      const raw = cookie().get(CURRENT_WALLET_KEY) as string;
+      const raw = cookie().get(ACTIVE_WALLET_KEY) as string;
       const parsed = JSON.parse(raw);
       expect(parsed.address).to.equal(OTHER_ADDRESS);
       a.cleanup();

--- a/test/addressPersistence.spec.ts
+++ b/test/addressPersistence.spec.ts
@@ -1,0 +1,274 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { JSDOM } from "jsdom";
+import { FormoAnalytics } from "../src/FormoAnalytics";
+import { initStorageManager, cookie } from "../src/storage";
+import { CURRENT_WALLET_KEY } from "../src/constants";
+
+/**
+ * Regressions for two issues that produced page events with empty `address`:
+ *
+ * 1. cleanup() didn't tear down the `popstate` / `locationchange` listeners
+ *    or restore `history.pushState` / `history.replaceState`. A re-mounted
+ *    SDK (React Strict Mode, HMR, options change) left an orphan instance
+ *    wired into the DOM that kept emitting page events with no address.
+ *
+ * 2. `currentAddress` was in-memory only. After a reload, the first page
+ *    hit fired before wagmi / EIP-1193 had a chance to reconnect, so it
+ *    shipped with no address. We now persist a snapshot on every
+ *    connect/identify and seed from it at init.
+ */
+describe("Address persistence and cleanup", () => {
+  let sandbox: sinon.SinonSandbox;
+  let jsdom: JSDOM;
+
+  const ADDRESS = "0x51377e9B985Bb90B7c091B9a7d30C93d4c9c1CEf";
+  const OTHER_ADDRESS = "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e";
+  const CHAIN_ID = 1;
+
+  const mkWagmi = (sb: sinon.SinonSandbox) => {
+    const mockWagmiConfig = {
+      subscribe: sb.stub().returns(() => {}),
+      state: { status: "disconnected", connections: new Map(), current: undefined, chainId: undefined },
+      _internal: { store: { subscribe: sb.stub().returns(() => {}) } },
+    };
+    const mockQueryClient = {
+      getMutationCache: () => ({ subscribe: sb.stub().returns(() => {}) }),
+      getQueryCache: () => ({ subscribe: sb.stub().returns(() => {}) }),
+    };
+    return { mockWagmiConfig, mockQueryClient };
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    jsdom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>", {
+      url: "https://example.com",
+    });
+    Object.defineProperty(global, "window", { value: jsdom.window, writable: true, configurable: true });
+    Object.defineProperty(global, "document", { value: jsdom.window.document, writable: true, configurable: true });
+    Object.defineProperty(global, "location", { value: jsdom.window.location, writable: true, configurable: true });
+    Object.defineProperty(global, "globalThis", { value: jsdom.window, writable: true, configurable: true });
+    Object.defineProperty(global, "navigator", { value: jsdom.window.navigator, writable: true, configurable: true });
+    Object.defineProperty(global, "localStorage", { value: jsdom.window.localStorage, writable: true, configurable: true });
+    Object.defineProperty(global, "sessionStorage", { value: jsdom.window.sessionStorage, writable: true, configurable: true });
+    Object.defineProperty(global, "crypto", {
+      value: { randomUUID: () => "mock-uuid-1234" },
+      writable: true, configurable: true,
+    });
+    // Make the bare `history` identifier in SDK code resolve to JSDOM's
+    // history, so trackPageHits actually wraps the real pushState/replaceState.
+    Object.defineProperty(global, "history", { value: jsdom.window.history, writable: true, configurable: true });
+
+    initStorageManager("test-write-key");
+    cookie().remove(CURRENT_WALLET_KEY);
+  });
+
+  afterEach(() => {
+    cookie().remove(CURRENT_WALLET_KEY);
+    sandbox.restore();
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).location;
+    delete (global as any).globalThis;
+    delete (global as any).navigator;
+    delete (global as any).localStorage;
+    delete (global as any).sessionStorage;
+    delete (global as any).crypto;
+    delete (global as any).history;
+    if (jsdom) jsdom.window.close();
+  });
+
+  describe("persists currentAddress across page reloads", () => {
+    it("connect() writes the snapshot cookie and a fresh init seeds from it", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      sandbox.stub(a as any, "trackEvent").resolves();
+      await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
+
+      expect(cookie().get(CURRENT_WALLET_KEY)).to.be.a("string");
+      a.cleanup();
+
+      // Simulate a reload by creating a fresh instance.
+      const { mockWagmiConfig: c2, mockQueryClient: q2 } = mkWagmi(sandbox);
+      const b = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: c2 as any, queryClient: q2 as any },
+      });
+
+      expect(b.currentAddress).to.equal(ADDRESS);
+      expect(b.currentChainId).to.equal(CHAIN_ID);
+      b.cleanup();
+    });
+
+    it("track() after a reload carries the persisted address", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      sandbox.stub(a as any, "trackEvent").resolves();
+      await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
+      a.cleanup();
+
+      const { mockWagmiConfig: c2, mockQueryClient: q2 } = mkWagmi(sandbox);
+      const b = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: c2 as any, queryClient: q2 as any },
+      });
+      const addEventStub = sandbox.stub((b as any).eventManager, "addEvent").resolves();
+
+      await b.track("Deposit Success", { value_usd: 508 });
+
+      expect(addEventStub.calledOnce).to.be.true;
+      const [, addressArg] = addEventStub.firstCall.args;
+      expect(addressArg).to.equal(ADDRESS);
+      b.cleanup();
+    });
+
+    it("disconnect() clears the persisted snapshot", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      sandbox.stub(a as any, "trackEvent").resolves();
+      await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
+      expect(cookie().get(CURRENT_WALLET_KEY)).to.be.a("string");
+
+      await a.disconnect({ chainId: CHAIN_ID, address: ADDRESS });
+      expect(cookie().get(CURRENT_WALLET_KEY)).to.satisfy(
+        (v: any) => v === undefined || v === null || v === ""
+      );
+      a.cleanup();
+    });
+
+    it("reset() clears the persisted snapshot", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      sandbox.stub(a as any, "trackEvent").resolves();
+      await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
+
+      a.reset();
+      expect(cookie().get(CURRENT_WALLET_KEY)).to.satisfy(
+        (v: any) => v === undefined || v === null || v === ""
+      );
+      a.cleanup();
+    });
+  });
+
+  describe("cleanup() detaches page-hit hooks", () => {
+    it("after cleanup the orphan instance stops handling pushState", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      const orphanOnLocationChange = sandbox.spy(a as any, "onLocationChange");
+      a.cleanup();
+
+      // Trigger a pushState — orphan must not handle it.
+      jsdom.window.history.pushState({}, "", "/orphan-target");
+      // Allow the synthetic event (if any) to dispatch.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(orphanOnLocationChange.called).to.be.false;
+    });
+
+    it("a fresh instance after cleanup still receives pushState events", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      a.cleanup();
+
+      const { mockWagmiConfig: c2, mockQueryClient: q2 } = mkWagmi(sandbox);
+      const b = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: c2 as any, queryClient: q2 as any },
+      });
+      const liveOnLocationChange = sandbox.spy(b as any, "onLocationChange");
+
+      jsdom.window.history.pushState({}, "", "/live-target");
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(liveOnLocationChange.called).to.be.true;
+      b.cleanup();
+    });
+
+    it("only the live instance emits a page event after a remount", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      const orphanAdd = sandbox.stub((a as any).eventManager, "addEvent").resolves();
+      a.cleanup();
+
+      const { mockWagmiConfig: c2, mockQueryClient: q2 } = mkWagmi(sandbox);
+      const b = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: c2 as any, queryClient: q2 as any },
+      });
+      const liveAdd = sandbox.stub((b as any).eventManager, "addEvent").resolves();
+
+      orphanAdd.resetHistory();
+      liveAdd.resetHistory();
+
+      jsdom.window.history.pushState({}, "", "/new-path");
+      // trackPageHit uses setTimeout(300); wait it out.
+      await new Promise((r) => setTimeout(r, 350));
+
+      // The orphan instance must not enqueue a page event anymore.
+      const orphanPageCalls = orphanAdd
+        .getCalls()
+        .filter((c: sinon.SinonSpyCall) => (c.args[0] as any)?.type === "page");
+      expect(orphanPageCalls.length).to.equal(0);
+
+      // The live instance still emits.
+      const livePageCalls = liveAdd
+        .getCalls()
+        .filter((c: sinon.SinonSpyCall) => (c.args[0] as any)?.type === "page");
+      expect(livePageCalls.length).to.be.greaterThan(0);
+      b.cleanup();
+    });
+
+    it("ignores a corrupt persisted snapshot and clears the cookie", async () => {
+      cookie().set(CURRENT_WALLET_KEY, "not-json{");
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      expect(a.currentAddress).to.be.undefined;
+      expect(cookie().get(CURRENT_WALLET_KEY)).to.satisfy(
+        (v: any) => v === undefined || v === null || v === ""
+      );
+      a.cleanup();
+    });
+
+    it("does not seed from a persisted invalid address", async () => {
+      cookie().set(
+        CURRENT_WALLET_KEY,
+        JSON.stringify({ address: "0xnot-an-address", chainId: CHAIN_ID })
+      );
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      expect(a.currentAddress).to.be.undefined;
+      a.cleanup();
+    });
+
+    it("a later connect() to a different address overwrites the persisted snapshot", async () => {
+      const { mockWagmiConfig, mockQueryClient } = mkWagmi(sandbox);
+      const a = await FormoAnalytics.init("test-write-key", {
+        wagmi: { config: mockWagmiConfig as any, queryClient: mockQueryClient as any },
+      });
+      sandbox.stub(a as any, "trackEvent").resolves();
+      await a.connect({ chainId: CHAIN_ID, address: ADDRESS });
+      await a.connect({ chainId: CHAIN_ID, address: OTHER_ADDRESS });
+
+      const raw = cookie().get(CURRENT_WALLET_KEY) as string;
+      const parsed = JSON.parse(raw);
+      expect(parsed.address).to.equal(OTHER_ADDRESS);
+      a.cleanup();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes two regressions that caused page events to ship with empty addresses:

1. **Orphaned instance cleanup**: The SDK's `cleanup()` method didn't properly tear down page-hit hooks (`popstate`/`locationchange` listeners and `history.pushState`/`replaceState` wrappers), leaving orphaned instances from re-mounts (React Strict Mode, HMR) still emitting page events with stale state.

2. **Address persistence across reloads**: The `currentAddress` was in-memory only. After a page reload, the first page hit fired before wagmi/EIP-1193 reconnection completed, shipping with no address. The SDK now persists a wallet snapshot on every connect/identify and seeds from it at init.

## Key Changes

- **Wallet persistence**: Added `persistCurrentWallet()` and `restorePersistedWallet()` methods that store/restore the current address and chainId in a cookie, allowing the SDK to repopulate state at init before wagmi reconnects.

- **Cleanup improvements**: Enhanced `cleanup()` to properly dispose of page-hit hooks by:
  - Storing listener references (`_onPopStateListener`, `_onLocationChangeListener`) so they can be removed
  - Setting `_pageHooksDisposed` flag that wrapped `history.pushState`/`replaceState` check before dispatching synthetic events
  - Preventing in-flight page hits from disposed instances via timeout check

- **Address backfill from autocapture**: Added `backfillEvmAddressIfEmpty()` method that persists EVM addresses discovered through signature/transaction autocapture when no address is currently set. This enables subsequent `track()`/`page()` calls to carry the address even when wallets never fire `accountsChanged` events (embedded wallets, smart accounts, social-login wrappers).

- **State management**: Updated `setChainState()` to call `persistCurrentWallet()` whenever address/chainId changes, and `reset()` to clear the persisted snapshot.

- **Constants**: Added `CURRENT_WALLET_KEY` constant for the persisted wallet cookie.

## Implementation Details

- The persisted snapshot is stored as JSON with address and optional chainId, using the same cookie domain/expiry logic as existing session cookies
- Corrupt or invalid persisted snapshots are silently cleared to prevent initialization failures
- Backfill only occurs when `currentAddress` is empty, never overwriting an explicitly connected address
- The `_pageHooksDisposed` flag is captured in closure by the wrapped history methods so cleaned-up instances become inert without unwinding the wrapper chain (allowing later instances to wrap on top)
- Comprehensive test coverage added for both persistence and cleanup scenarios

https://claude.ai/code/session_01UxeMWkcbKiYV6hBSK5WArh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->