### PR TITLE
fix(security): isolate release publish privileges; stop post-opt-out …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,31 @@ on:
     tags:
       - 'v*'
 
+# Least privilege by default. Only the `publish` job escalates, and it
+# runs no project or third-party dependency code (see job comments).
 permissions:
-  id-token: write  # Required for OIDC trusted publishing
-  contents: write  # Required for creating GitHub releases
+  contents: read
 
 jobs:
-  publish:
+  # ---------------------------------------------------------------------------
+  # build — UNPRIVILEGED
+  #
+  # Runs everything that executes untrusted third-party code: dependency
+  # install (lifecycle scripts), build tooling, and tests. It has NO
+  # `id-token: write` and NO `contents: write`, and checks out with
+  # `persist-credentials: false`, so a compromised dependency / build / test
+  # script running here has no npm-publish OIDC token, no writable GITHUB_TOKEN,
+  # and no persisted git credential to exfiltrate. The release gates (semver
+  # tag validation, main-branch check, version match, tests) run here and the
+  # privileged `publish` job only runs via `needs: build`, so they still gate
+  # every release.
+  # ---------------------------------------------------------------------------
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     # Bind workflow-context values to env up front. Steps reference these
     # as shell variables ($TAG, $REPO, $COMMIT_SHA) instead of `${{ }}`
     # template interpolation, so attacker-controlled tag names cannot be
@@ -38,6 +56,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Fetch all history for changelog generation
+          persist-credentials: false  # No git credential left on disk for build/test code
 
       - name: Verify tag is on main branch
         run: |
@@ -60,9 +79,6 @@ jobs:
           node-version: "22.14.0"
           cache: 'pnpm'
           # No registry-url - using OIDC trusted publishing instead
-
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -96,6 +112,17 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Pack publishable tarball
+        # Produce the exact artifact that will be published. `npm pack` packs
+        # the `files` allowlist from package.json; this project defines no
+        # prepare/prepack/prepublishOnly scripts, so no extra code runs here,
+        # and `npm publish <tarball>` later runs no lifecycle scripts at all.
+        run: |
+          TARBALL=$(npm pack --json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8'))[0].filename")
+          echo "Packed: $TARBALL"
+          mkdir -p release-artifact
+          mv "$TARBALL" release-artifact/package.tgz
 
       - name: Generate release notes
         id: release_notes
@@ -166,13 +193,13 @@ jobs:
           done <<< "$COMMITS"
 
           # Create release notes
-          cat > release_notes.md <<EOF
+          cat > release-artifact/release_notes.md <<EOF
           $VERSION ($RELEASE_DATE)
           EOF
 
           # Add Features section if exists
           if [ -n "$FEATURES" ]; then
-            cat >> release_notes.md <<EOF
+            cat >> release-artifact/release_notes.md <<EOF
 
           ## Features
 
@@ -182,7 +209,7 @@ jobs:
 
           # Add Fixes section if exists
           if [ -n "$FIXES" ]; then
-            cat >> release_notes.md <<EOF
+            cat >> release-artifact/release_notes.md <<EOF
 
           ## Bug Fixes
 
@@ -192,7 +219,7 @@ jobs:
 
           # Add Other changes if exists
           if [ -n "$OTHER" ]; then
-            cat >> release_notes.md <<EOF
+            cat >> release-artifact/release_notes.md <<EOF
 
           ## Changes
 
@@ -201,7 +228,7 @@ jobs:
           fi
 
           # Add npm package link
-          cat >> release_notes.md <<EOF
+          cat >> release-artifact/release_notes.md <<EOF
 
           ## Install
 
@@ -222,15 +249,91 @@ jobs:
           \`\`\`
           EOF
 
+      - name: Upload release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-package
+          path: release-artifact/
+          retention-days: 1
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # publish — PRIVILEGED, MINIMAL
+  #
+  # Holds `id-token: write` (npm trusted publishing / provenance) and
+  # `contents: write` (GitHub release). It runs NO `pnpm install`, build,
+  # or tests, so no third-party dependency lifecycle script and no project
+  # build/test code ever executes with these credentials. Its only
+  # checkout is a minimal `persist-credentials: false` checkout of the
+  # immutable tag, used solely to obtain the first-party SRI script (no
+  # untrusted code runs from it). It only: installs npm itself (the
+  # publish tool), verifies + publishes the prebuilt tarball (tarball
+  # publish runs no lifecycle scripts), creates the release, and runs the
+  # first-party SRI script from the tag checkout.
+  # ---------------------------------------------------------------------------
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing + provenance
+      contents: write  # Required for creating GitHub releases
+    env:
+      # Sourced from the validated tag in the trusted build job and bound to
+      # env (not inline `${{ }}`) so it cannot be injected into run bodies.
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Checkout repository at the validated tag
+        # Provides the first-party post-publish SRI script from the
+        # immutable tag, NOT the build artifact. Code that ran in the
+        # unprivileged build job (dependency lifecycle / build / test)
+        # therefore cannot tamper with what executes in this privileged
+        # job. `persist-credentials: false` leaves no git push token on
+        # disk; no dependency install / build / test runs here.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-package
+          path: release-package
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22.14.0"
+          # No registry-url - using OIDC trusted publishing instead
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Verify tarball identity matches the validated tag
+        # The tarball was packed by the UNPRIVILEGED build job, after
+        # untrusted install/build/test code ran. Before publishing it with
+        # the OIDC token, assert it is exactly @formo/analytics@$VERSION
+        # (the version was already gated against the tag in `build`), so a
+        # mutated package.json cannot redirect the trusted publish.
+        run: |
+          PKG_JSON=$(tar -xzOf ./release-package/package.tgz package/package.json)
+          NAME=$(printf '%s' "$PKG_JSON" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).name")
+          VER=$(printf '%s' "$PKG_JSON" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          if [ "$NAME" != "@formo/analytics" ] || [ "$VER" != "$VERSION" ]; then
+            echo "❌ Tarball identity mismatch: got '$NAME@$VER', expected '@formo/analytics@$VERSION'"
+            exit 1
+          fi
+          echo "✅ Tarball verified: $NAME@$VER"
+
       - name: Publish to npm
-        run: npm publish --provenance
-        # Explicitly use --provenance flag for clarity
-        # OIDC trusted publishing (id-token: write) enables automatic provenance generation
+        # Publishing the prebuilt tarball runs no prepare/prepack/prepublish
+        # lifecycle scripts. OIDC trusted publishing (id-token: write) enables
+        # automatic provenance generation.
+        run: npm publish ./release-package/package.tgz --provenance --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          body_path: release_notes.md
+          body_path: release-package/release_notes.md
           draft: false
           prerelease: false
         env:
@@ -238,7 +341,6 @@ jobs:
 
       - name: Generate and Add SRI to GitHub Release
         env:
-          VERSION: ${{ steps.version.outputs.version }}
           GH_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Published version: $VERSION"
@@ -251,4 +353,5 @@ jobs:
             bash scripts/generate-sri.sh "$VERSION"
           else
             echo "⚠️ SRI script not found at scripts/generate-sri.sh"
+            exit 1
           fi

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -39,6 +39,14 @@ async function fetchWithRetry(
         if (retryDelay) {
           await new Promise((resolve) => setTimeout(resolve, retryDelay(attempt)));
         }
+        // Re-check after the backoff delay. retryOn is a caller-supplied
+        // gate that can change its mind during the wait (e.g. tracking
+        // consent withdrawn mid-backoff). Without this re-check, an
+        // opt-out during the multi-second delay would still let the next
+        // attempt fire — a post-opt-out send.
+        if (retryOn?.(attempt, responseError, response) === false) {
+          return response;
+        }
         continue;
       }
 
@@ -53,6 +61,11 @@ async function fetchWithRetry(
       if (retryOn?.(attempt, error as FetchRetryError, null)) {
         if (retryDelay) {
           await new Promise((resolve) => setTimeout(resolve, retryDelay(attempt)));
+        }
+        // Re-check after the backoff delay (see the response path above):
+        // the caller's gate may have flipped during the wait.
+        if (retryOn?.(attempt, error as FetchRetryError, null) === false) {
+          throw error;
         }
         continue;
       }

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -362,7 +362,17 @@ export class EventQueue implements IEventQueue {
           keepalive: batch.keepalive,
           retries: this.retryCount,
           retryDelay: (attempt) => Math.pow(2, attempt) * 1_000,
-          retryOn: (_, error, response) => this.isErrorRetryable(error, response),
+          retryOn: (_, error, response) => {
+            // Consent can be withdrawn mid-flush while this fetch is
+            // already in its retry/backoff chain (exponential backoff
+            // spans up to tens of seconds). retryOn is consulted before
+            // every retry's delay + next attempt, so returning false
+            // here aborts all remaining retries immediately — no event
+            // is re-sent after opt-out. A post-opt-out send is a
+            // GDPR/CCPA violation, not just stale data.
+            if (this.canSend && !this.canSend()) return false;
+            return this.isErrorRetryable(error, response);
+          },
         });
         if (!response.ok) {
           const error: any = new Error(response.statusText || `HTTP ${response.status}`);

--- a/test/lib/fetch/fetch.spec.ts
+++ b/test/lib/fetch/fetch.spec.ts
@@ -221,5 +221,33 @@ describe("fetchWithRetry", () => {
 
       clock.restore();
     });
+
+    it("should NOT retry when retryOn flips to false during the backoff delay (consent withdrawn mid-backoff)", async () => {
+      // GDPR/CCPA: if tracking consent is withdrawn while a fetch is
+      // already sleeping in its retry backoff, the next attempt must not
+      // fire. retryOn here mirrors EventQueue's `canSend()` gate.
+      const clock = sinon.useFakeTimers();
+      const networkError = new TypeError("Failed to fetch");
+      fetchStub.rejects(networkError);
+
+      let consentGranted = true;
+      const resultPromise = fetchWithRetry("https://api.example.com", {
+        retries: 3,
+        retryOn: () => consentGranted,
+        retryDelay: () => 1_000,
+      }).catch((e) => e);
+
+      // First attempt failed; retryOn(true) scheduled a 1s backoff.
+      // Consent is withdrawn WHILE that backoff timer is still sleeping:
+      consentGranted = false;
+      await clock.tickAsync(1_000);
+
+      const result = await resultPromise;
+      expect(result).to.equal(networkError);
+      // Only the initial attempt — no post-opt-out retry was sent.
+      expect(fetchStub.calledOnce).to.be.true;
+
+      clock.restore();
+    });
   });
 });


### PR DESCRIPTION
…sends

Release workflow (.github/workflows/release.yml):
- Split the single privileged publish job into an UNPRIVILEGED `build` job (contents: read, checkout persist-credentials: false) that runs install/build/test/npm-pack, and a MINIMAL privileged `publish` job (id-token: write + contents: write, needs: build). No third-party dependency lifecycle / build / test code runs with the npm OIDC token or a writable GITHUB_TOKEN anymore.
- publish runs the first-party SRI script from a credential-less checkout of the immutable tag, not the build artifact, so build-time code cannot tamper with what the privileged job executes.
- publish verifies the tarball name/version match the validated tag before `npm publish`.

Consent (src/queue/EventQueue.ts, src/fetch/index.ts):
- retryOn aborts the retry chain when tracking consent is withdrawn, and fetchWithRetry re-checks retryOn AFTER the backoff delay, so an opt-out during the multi-second backoff cannot trigger a post-opt-out network send (GDPR/CCPA). Adds a fake-timer regression test asserting only one fetch occurs when consent flips mid-backoff.

Reviewed by Codex (gpt-5.5, high effort); all raised issues resolved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->