### PR TITLE
Implement sticky referrer tracking with first-touch attribution

### DIFF
--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -189,8 +189,12 @@ class EventFactory implements IEventFactory {
 
     const finalTrafficSources: ITrafficSource = {
       ref: contextTrafficSources.ref || storedTrafficSources?.ref || "",
+      // Referrer is sticky (first-touch wins): document.referrer is populated
+      // by the browser on every internal navigation with the previous page,
+      // which would overwrite the session's entry referrer. Prefer the stored
+      // value so attribution reflects the session's true source.
       referrer:
-        contextTrafficSources.referrer || storedTrafficSources?.referrer || "",
+        storedTrafficSources?.referrer || contextTrafficSources.referrer || "",
       utm_campaign:
         contextTrafficSources.utm_campaign ||
         storedTrafficSources?.utm_campaign ||

--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -170,13 +170,30 @@ class EventFactory implements IEventFactory {
     return "";
   };
 
+  /**
+   * Returns the document referrer with same-host referrers filtered out.
+   * Internal navigation populates `document.referrer` with the previous page
+   * on the same site, which is not an attribution signal — treating it as
+   * "external" would otherwise let an internal URL become the session's
+   * first-touch referrer after a direct landing.
+   */
+  private getExternalReferrer = (): string => {
+    const ref = document.referrer;
+    if (!ref) return "";
+    try {
+      const currentHost = globalThis.location?.hostname;
+      if (currentHost && new URL(ref).hostname === currentHost) return "";
+    } catch {}
+    return ref;
+  };
+
   private getTrafficSources = (url: string): ITrafficSource => {
     const urlObj = new URL(url);
     const contextTrafficSources: ITrafficSource = {
       ...this.extractUTMParameters(url),
       ...this.extractClickIdParameters(urlObj),
       ref: this.extractReferralParameter(urlObj),
-      referrer: document.referrer,
+      referrer: this.getExternalReferrer(),
     };
     const storedTrafficSources =
       (session().get(SESSION_TRAFFIC_SOURCE_KEY) as ITrafficSource) || {};
@@ -189,10 +206,10 @@ class EventFactory implements IEventFactory {
 
     const finalTrafficSources: ITrafficSource = {
       ref: contextTrafficSources.ref || storedTrafficSources?.ref || "",
-      // Referrer is sticky (first-touch wins): document.referrer is populated
-      // by the browser on every internal navigation with the previous page,
-      // which would overwrite the session's entry referrer. Prefer the stored
-      // value so attribution reflects the session's true source.
+      // Referrer is sticky (first-touch wins). Same-host referrers are already
+      // stripped by getExternalReferrer; the stored-first OR keeps the entry
+      // referrer pinned even if a later pageview reports a different external
+      // referrer (e.g. cross-domain return from an outbound click).
       referrer:
         storedTrafficSources?.referrer || contextTrafficSources.referrer || "",
       utm_campaign:

--- a/test/lib/event/PagePropertiesParsing.spec.ts
+++ b/test/lib/event/PagePropertiesParsing.spec.ts
@@ -776,6 +776,33 @@ describe("Page Event Property Parsing", () => {
       const freshContext = await getPageContext();
       expect(freshContext.referrer).to.equal("");
     });
+
+    it("should not capture internal navigation as referrer after a direct landing", async () => {
+      // Direct landing: no referrer, nothing stored.
+      setMockLocation("https://formo.so/");
+      const landingContext = await getPageContext();
+      expect(landingContext.referrer).to.equal("");
+
+      // Internal nav: browser sets document.referrer to the previous same-host
+      // page. This must NOT be treated as the session's entry referrer.
+      setMockLocation("https://formo.so/dashboard", "https://formo.so/");
+      const secondContext = await getPageContext();
+      expect(secondContext.referrer).to.equal("");
+
+      // A subsequent internal hop must also stay empty — i.e. the previous
+      // same-host URL did not sneak into sessionStorage on the prior event.
+      setMockLocation("https://formo.so/pricing", "https://formo.so/dashboard");
+      const thirdContext = await getPageContext();
+      expect(thirdContext.referrer).to.equal("");
+    });
+
+    it("should treat a different host as external even when paths look similar", async () => {
+      // Sanity: cross-host nav is still captured (we filter on hostname, not
+      // arbitrary URL substrings).
+      setMockLocation("https://formo.so/", "https://app.formo.so/");
+      const context = await getPageContext();
+      expect(context.referrer).to.equal("https://app.formo.so/");
+    });
   });
 });
 

--- a/test/lib/event/PagePropertiesParsing.spec.ts
+++ b/test/lib/event/PagePropertiesParsing.spec.ts
@@ -124,15 +124,17 @@ describe("Page Event Property Parsing", () => {
   /**
    * Helper function to set mock location by creating a new JSDOM with the desired URL
    */
-  function setMockLocation(url: string) {
+  function setMockLocation(url: string, referrer?: string) {
     // Close previous JSDOM
     if (jsdom) {
       jsdom.window.close();
     }
-    
+
     // Create new JSDOM with the desired URL
-    jsdom = new JSDOM("<!DOCTYPE html><html><head><title>Test Page</title></head><body></body></html>", { url });
-    
+    const options: ConstructorParameters<typeof JSDOM>[1] = { url };
+    if (referrer !== undefined) options.referrer = referrer;
+    jsdom = new JSDOM("<!DOCTYPE html><html><head><title>Test Page</title></head><body></body></html>", options);
+
     // Update globals
     (global as any).window = jsdom.window;
     (global as any).document = jsdom.window.document;
@@ -707,6 +709,72 @@ describe("Page Event Property Parsing", () => {
       const context = await getPageContext();
 
       expect(context.random_clid).to.be.undefined;
+    });
+  });
+
+  describe("Referrer (sticky across session)", () => {
+    // Clear stored traffic-source state between tests so each scenario starts
+    // from a clean session.
+    beforeEach(() => {
+      try {
+        session().remove(SESSION_TRAFFIC_SOURCE_KEY);
+      } catch {}
+    });
+
+    it("should capture document.referrer into context on the landing pageview", async () => {
+      setMockLocation("https://formo.so/", "https://google.com/");
+
+      const context = await getPageContext();
+
+      expect(context.referrer).to.equal("https://google.com/");
+    });
+
+    it("should persist the entry referrer across internal navigation", async () => {
+      // Landing: external referrer is captured and stored.
+      setMockLocation("https://formo.so/", "https://google.com/");
+      const landingContext = await getPageContext();
+      expect(landingContext.referrer).to.equal("https://google.com/");
+
+      // Internal navigation: browser sets document.referrer to the previous
+      // same-domain page. The sticky stored value must win so attribution
+      // continues to reflect the session's true source.
+      setMockLocation("https://formo.so/dashboard", "https://formo.so/");
+      const secondContext = await getPageContext();
+      expect(secondContext.referrer).to.equal("https://google.com/");
+    });
+
+    it("should not overwrite a stored referrer when a different external referrer appears mid-session", async () => {
+      setMockLocation("https://formo.so/", "https://google.com/");
+      await getPageContext();
+
+      // User clicks an outbound link and comes back via a different referrer.
+      // First-touch attribution wins.
+      setMockLocation("https://formo.so/landing", "https://facebook.com/");
+      const secondContext = await getPageContext();
+      expect(secondContext.referrer).to.equal("https://google.com/");
+    });
+
+    it("should fall back to document.referrer when no stored referrer exists", async () => {
+      // Fresh session with no stored value yet: context wins via the OR fallback.
+      setMockLocation("https://formo.so/landing", "https://twitter.com/");
+
+      const context = await getPageContext();
+
+      expect(context.referrer).to.equal("https://twitter.com/");
+    });
+
+    it("should not leak referrer into a fresh session", async () => {
+      // Landing pageview writes referrer to sessionStorage.
+      setMockLocation("https://formo.so/", "https://google.com/");
+      await getPageContext();
+
+      // Simulate a brand new session (new tab): sessionStorage is empty.
+      session().remove(SESSION_TRAFFIC_SOURCE_KEY);
+
+      // Direct landing with no referrer in the new session.
+      setMockLocation("https://formo.so/dashboard");
+      const freshContext = await getPageContext();
+      expect(freshContext.referrer).to.equal("");
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR implements sticky referrer tracking to ensure first-touch attribution is preserved across a user's session. Previously, the referrer value could be overwritten during internal navigation because the browser automatically updates `document.referrer` to the previous page URL. Now, the stored referrer value takes precedence, maintaining accurate session source attribution.

## Key Changes
- **EventFactory.ts**: Reversed the precedence order for referrer resolution to prioritize stored values over context values, ensuring the initial session referrer is never overwritten by internal navigation
- **PagePropertiesParsing.spec.ts**: 
  - Enhanced `setMockLocation()` helper to accept an optional `referrer` parameter for testing different referrer scenarios
  - Added comprehensive test suite "Referrer (sticky across session)" with 5 test cases covering:
    - Capturing initial referrer on landing pageview
    - Persisting entry referrer across internal navigation
    - Preventing mid-session external referrer from overwriting initial value
    - Falling back to document.referrer when no stored value exists
    - Ensuring referrer doesn't leak into fresh sessions

## Implementation Details
The fix leverages session storage to maintain the entry referrer across page navigations. The logic now follows: `storedTrafficSources?.referrer || contextTrafficSources.referrer || ""`, ensuring that once a referrer is captured at session start, it remains sticky throughout the session while still allowing fallback to document.referrer for fresh sessions with no stored value.

https://claude.ai/code/session_018WEzHcE3XDMxo5pqn27vLw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782557418&installation_id=130740768&pr_number=271&repository=getformo%2Fsdk&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fsdk%2Fpull%2F271&signature=0c8036105329292524f88ea7e272744115628f1060c6bdda1f3f337c010ae7c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->