### PR TITLE
Add query parameter redaction for sensitive data

### DIFF
--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -47,16 +47,25 @@ class EventFactory implements IEventFactory {
   // with any opt-in keys from `options.tracking.excludeQueryParams`. The
   // built-ins are always present and cannot be removed by configuration.
   private excludedQueryParams: Set<string>;
+  // Optional consumer-supplied predicate for arbitrary query-param exclusion
+  // logic (e.g. prefix/regex on the key, or matching on the value). Applied in
+  // addition to — and after — the key-based denylist above, so it can only add
+  // exclusions, never re-enable a built-in default.
+  private excludeQueryParamFn?: (key: string, value: string) => boolean;
 
   constructor(options?: Options) {
     this.options = options;
     const tracking = options?.tracking;
     const configuredExcludes =
-      typeof tracking === "object" ? tracking.excludeQueryParams ?? [] : [];
+      typeof tracking === "object" ? tracking.excludeQueryParams : undefined;
+    if (typeof configuredExcludes === "function") {
+      this.excludeQueryParamFn = configuredExcludes;
+    }
     this.excludedQueryParams = new Set(
-      [...DEFAULT_EXCLUDED_QUERY_PARAMS, ...configuredExcludes].map((key) =>
-        key.toLowerCase()
-      )
+      [
+        ...DEFAULT_EXCLUDED_QUERY_PARAMS,
+        ...(Array.isArray(configuredExcludes) ? configuredExcludes : []),
+      ].map((key) => key.toLowerCase())
     );
     // Compile regex pattern once for better performance
     if (options?.referral?.pathPattern) {
@@ -125,8 +134,22 @@ class EventFactory implements IEventFactory {
     return version;
   }
 
-  private isExcludedQueryParam(key: string): boolean {
-    return this.excludedQueryParams.has(key.toLowerCase());
+  private isExcludedQueryParam(key: string, value: string): boolean {
+    if (this.excludedQueryParams.has(key.toLowerCase())) {
+      return true;
+    }
+    if (this.excludeQueryParamFn) {
+      try {
+        return this.excludeQueryParamFn(key, value) === true;
+      } catch (error) {
+        // A consumer predicate must never break tracking. Log and fail open
+        // (do not exclude on error); the always-on built-in denylist above
+        // still guarantees the critical secrets are stripped.
+        logger.error("Error in tracking.excludeQueryParams predicate:", error);
+        return false;
+      }
+    }
+    return false;
   }
 
   /**
@@ -134,11 +157,15 @@ class EventFactory implements IEventFactory {
    * query string is touched; the path and hash/fragment are left as-is.
    */
   private redactQueryParams(url: URL): void {
-    for (const key of Array.from(url.searchParams.keys())) {
-      if (this.isExcludedQueryParam(key)) {
-        url.searchParams.delete(key);
+    // Collect first, then delete: mutating searchParams while iterating is
+    // unsafe, and deleting a key removes all of its values at once.
+    const keysToDelete = new Set<string>();
+    url.searchParams.forEach((value, key) => {
+      if (this.isExcludedQueryParam(key, value)) {
+        keysToDelete.add(key);
       }
-    }
+    });
+    keysToDelete.forEach((key) => url.searchParams.delete(key));
   }
 
   /**

--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -29,6 +29,7 @@ import { version } from "../version";
 import {
   CHANNEL,
   CLICK_ID_PARAMS,
+  DEFAULT_EXCLUDED_QUERY_PARAMS,
   PAGE_PROPERTIES_EXCLUDED_FIELDS,
   VERSION,
 } from "./constants";
@@ -42,15 +43,19 @@ class EventFactory implements IEventFactory {
   private options?: Options;
   private compiledPathPattern?: RegExp;
   // Lower-cased query-param keys that must never be forwarded to or stored by
-  // Formo. Opt-in via `options.tracking.excludeQueryParams`; empty by default.
+  // Formo: a built-in always-on denylist (DEFAULT_EXCLUDED_QUERY_PARAMS) merged
+  // with any opt-in keys from `options.tracking.excludeQueryParams`. The
+  // built-ins are always present and cannot be removed by configuration.
   private excludedQueryParams: Set<string>;
 
   constructor(options?: Options) {
     this.options = options;
     const tracking = options?.tracking;
+    const configuredExcludes =
+      typeof tracking === "object" ? tracking.excludeQueryParams ?? [] : [];
     this.excludedQueryParams = new Set(
-      (typeof tracking === "object" ? tracking.excludeQueryParams ?? [] : []).map(
-        (key) => key.toLowerCase()
+      [...DEFAULT_EXCLUDED_QUERY_PARAMS, ...configuredExcludes].map((key) =>
+        key.toLowerCase()
       )
     );
     // Compile regex pattern once for better performance
@@ -129,7 +134,6 @@ class EventFactory implements IEventFactory {
    * query string is touched; the path and hash/fragment are left as-is.
    */
   private redactQueryParams(url: URL): void {
-    if (this.excludedQueryParams.size === 0) return;
     for (const key of Array.from(url.searchParams.keys())) {
       if (this.isExcludedQueryParam(key)) {
         url.searchParams.delete(key);
@@ -139,11 +143,11 @@ class EventFactory implements IEventFactory {
 
   /**
    * Return the given absolute URL with excluded query parameters removed. The
-   * input is returned unchanged when there is nothing to strip or it cannot be
-   * parsed (e.g. an empty referrer).
+   * input is returned unchanged when it is empty or cannot be parsed (e.g. an
+   * empty referrer).
    */
   private redactUrl(href: string): string {
-    if (!href || this.excludedQueryParams.size === 0) return href;
+    if (!href) return href;
     try {
       const url = new URL(href);
       this.redactQueryParams(url);

--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -237,6 +237,28 @@ class EventFactory implements IEventFactory {
     return this.redactUrl(ref);
   };
 
+  /**
+   * Apply the current query-param denylist to a previously-persisted traffic
+   * source object. Traffic-source keys (utm_*, click ids, ref) are themselves
+   * query-parameter names, so an excluded key's stored value is dropped; the
+   * referrer is a URL and is re-redacted. Guards against a stored value
+   * outliving the config (or SDK version) under which it was first captured.
+   */
+  private redactStoredTrafficSources(stored: ITrafficSource): ITrafficSource {
+    const result = {} as ITrafficSource;
+    for (const key of Object.keys(stored) as (keyof ITrafficSource)[]) {
+      const value = stored[key];
+      if (key === "referrer") {
+        result[key] = this.redactUrl((value as string) || "");
+      } else if (this.isExcludedQueryParam(key)) {
+        result[key] = "";
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
   private getTrafficSources = (url: string): ITrafficSource => {
     const urlObj = new URL(url);
     const contextTrafficSources: ITrafficSource = {
@@ -245,8 +267,13 @@ class EventFactory implements IEventFactory {
       ref: this.extractReferralParameter(urlObj),
       referrer: this.getExternalReferrer(),
     };
-    const storedTrafficSources =
-      (session().get(SESSION_TRAFFIC_SOURCE_KEY) as ITrafficSource) || {};
+    // Sticky traffic sources may have been persisted by an older SDK version or
+    // a looser config, before the current excludeQueryParams was in effect.
+    // Honor the current denylist on the way out so excluded values can never
+    // resurface from session storage (or get re-persisted below).
+    const storedTrafficSources = this.redactStoredTrafficSources(
+      (session().get(SESSION_TRAFFIC_SOURCE_KEY) as ITrafficSource) || {}
+    );
 
     const mergedClickIds = {} as ClickIdParameters;
     for (const p of CLICK_ID_PARAMS) {
@@ -342,15 +369,20 @@ class EventFactory implements IEventFactory {
     const location = this.getLocation();
     const library_version = this.getLibraryVersion();
 
+    // Redact once and reuse: traffic-source extraction (utm_*, click ids, ref)
+    // must operate on the already-stripped URL too, otherwise an excluded param
+    // that happens to be a traffic-source key would still leak via context.
+    const redactedHref = this.redactUrl(globalThis.location.href);
+
     // contextual properties
     const defaultContext = {
       user_agent: globalThis.navigator.userAgent,
       locale: language,
       timezone,
       location,
-      ...this.getTrafficSources(globalThis.location.href),
+      ...this.getTrafficSources(redactedHref),
       page_title: document.title,
-      page_url: this.redactUrl(globalThis.location.href),
+      page_url: redactedHref,
       library_name: "Formo Web SDK",
       library_version,
       browser: browserName,

--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -41,9 +41,18 @@ const ISO_3166_ALPHA_2_REGEX = /^[A-Z]{2}$/;
 class EventFactory implements IEventFactory {
   private options?: Options;
   private compiledPathPattern?: RegExp;
+  // Lower-cased query-param keys that must never be forwarded to or stored by
+  // Formo. Opt-in via `options.tracking.excludeQueryParams`; empty by default.
+  private excludedQueryParams: Set<string>;
 
   constructor(options?: Options) {
     this.options = options;
+    const tracking = options?.tracking;
+    this.excludedQueryParams = new Set(
+      (typeof tracking === "object" ? tracking.excludeQueryParams ?? [] : []).map(
+        (key) => key.toLowerCase()
+      )
+    );
     // Compile regex pattern once for better performance
     if (options?.referral?.pathPattern) {
       try {
@@ -109,6 +118,39 @@ class EventFactory implements IEventFactory {
 
   private getLibraryVersion(): string {
     return version;
+  }
+
+  private isExcludedQueryParam(key: string): boolean {
+    return this.excludedQueryParams.has(key.toLowerCase());
+  }
+
+  /**
+   * Strip excluded (sensitive) query parameters from a URL in place. Only the
+   * query string is touched; the path and hash/fragment are left as-is.
+   */
+  private redactQueryParams(url: URL): void {
+    if (this.excludedQueryParams.size === 0) return;
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (this.isExcludedQueryParam(key)) {
+        url.searchParams.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Return the given absolute URL with excluded query parameters removed. The
+   * input is returned unchanged when there is nothing to strip or it cannot be
+   * parsed (e.g. an empty referrer).
+   */
+  private redactUrl(href: string): string {
+    if (!href || this.excludedQueryParams.size === 0) return href;
+    try {
+      const url = new URL(href);
+      this.redactQueryParams(url);
+      return url.href;
+    } catch {
+      return href;
+    }
   }
 
   private extractUTMParameters = (url: string): UTMParameters => {
@@ -184,7 +226,7 @@ class EventFactory implements IEventFactory {
       const currentHost = globalThis.location?.hostname;
       if (currentHost && new URL(ref).hostname === currentHost) return "";
     } catch {}
-    return ref;
+    return this.redactUrl(ref);
   };
 
   private getTrafficSources = (url: string): ITrafficSource => {
@@ -300,7 +342,7 @@ class EventFactory implements IEventFactory {
       location,
       ...this.getTrafficSources(globalThis.location.href),
       page_title: document.title,
-      page_url: globalThis.location.href,
+      page_url: this.redactUrl(globalThis.location.href),
       library_name: "Formo Web SDK",
       library_version,
       browser: browserName,
@@ -326,8 +368,17 @@ class EventFactory implements IEventFactory {
     // Create a copy to avoid mutating the original properties object
     const pageProps = { ...properties };
 
+    // Parse the current URL once and strip any excluded (sensitive) query
+    // params up front, so nothing sensitive is forwarded via url, query, or the
+    // per-param explosion below. The hash/fragment is intentionally untouched.
+    let urlObj: URL | null = null;
+    try {
+      urlObj = new URL(globalThis.location.href);
+      this.redactQueryParams(urlObj);
+    } catch {}
+
     if (isUndefined(pageProps.url)) {
-      pageProps.url = new URL(globalThis.location.href).href;
+      pageProps.url = urlObj ? urlObj.href : globalThis.location.href;
     }
 
     if (isUndefined(pageProps.path)) {
@@ -340,19 +391,23 @@ class EventFactory implements IEventFactory {
 
     // Add query string without the '?' prefix
     if (isUndefined(pageProps.query)) {
-      pageProps.query = globalThis.location.search.slice(1);
+      pageProps.query = urlObj
+        ? urlObj.search.slice(1)
+        : globalThis.location.search.slice(1);
     }
 
     // Parse query parameters and add as individual properties (don't overwrite existing)
-    // Skip fields that are already captured in context or are semantic event properties
+    // Skip fields that are already captured in context or are semantic event properties.
+    // Excluded params were already removed from urlObj above.
     try {
-      const urlObj = new URL(globalThis.location.href);
-      urlObj.searchParams.forEach((value, key) => {
-        // Only add if the property doesn't already exist and is not excluded
-        if (isUndefined(pageProps[key]) && !PAGE_PROPERTIES_EXCLUDED_FIELDS.has(key)) {
-          pageProps[key] = value;
-        }
-      });
+      if (urlObj) {
+        urlObj.searchParams.forEach((value, key) => {
+          // Only add if the property doesn't already exist and is not excluded
+          if (isUndefined(pageProps[key]) && !PAGE_PROPERTIES_EXCLUDED_FIELDS.has(key)) {
+            pageProps[key] = value;
+          }
+        });
+      }
     } catch (error) {
       logger.error("Error parsing query parameters for page properties:", error);
     }

--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -47,25 +47,16 @@ class EventFactory implements IEventFactory {
   // with any opt-in keys from `options.tracking.excludeQueryParams`. The
   // built-ins are always present and cannot be removed by configuration.
   private excludedQueryParams: Set<string>;
-  // Optional consumer-supplied predicate for arbitrary query-param exclusion
-  // logic (e.g. prefix/regex on the key, or matching on the value). Applied in
-  // addition to — and after — the key-based denylist above, so it can only add
-  // exclusions, never re-enable a built-in default.
-  private excludeQueryParamFn?: (key: string, value: string) => boolean;
 
   constructor(options?: Options) {
     this.options = options;
     const tracking = options?.tracking;
     const configuredExcludes =
-      typeof tracking === "object" ? tracking.excludeQueryParams : undefined;
-    if (typeof configuredExcludes === "function") {
-      this.excludeQueryParamFn = configuredExcludes;
-    }
+      typeof tracking === "object" ? tracking.excludeQueryParams ?? [] : [];
     this.excludedQueryParams = new Set(
-      [
-        ...DEFAULT_EXCLUDED_QUERY_PARAMS,
-        ...(Array.isArray(configuredExcludes) ? configuredExcludes : []),
-      ].map((key) => key.toLowerCase())
+      [...DEFAULT_EXCLUDED_QUERY_PARAMS, ...configuredExcludes].map((key) =>
+        key.toLowerCase()
+      )
     );
     // Compile regex pattern once for better performance
     if (options?.referral?.pathPattern) {
@@ -134,22 +125,8 @@ class EventFactory implements IEventFactory {
     return version;
   }
 
-  private isExcludedQueryParam(key: string, value: string): boolean {
-    if (this.excludedQueryParams.has(key.toLowerCase())) {
-      return true;
-    }
-    if (this.excludeQueryParamFn) {
-      try {
-        return this.excludeQueryParamFn(key, value) === true;
-      } catch (error) {
-        // A consumer predicate must never break tracking. Log and fail open
-        // (do not exclude on error); the always-on built-in denylist above
-        // still guarantees the critical secrets are stripped.
-        logger.error("Error in tracking.excludeQueryParams predicate:", error);
-        return false;
-      }
-    }
-    return false;
+  private isExcludedQueryParam(key: string): boolean {
+    return this.excludedQueryParams.has(key.toLowerCase());
   }
 
   /**
@@ -160,8 +137,8 @@ class EventFactory implements IEventFactory {
     // Collect first, then delete: mutating searchParams while iterating is
     // unsafe, and deleting a key removes all of its values at once.
     const keysToDelete = new Set<string>();
-    url.searchParams.forEach((value, key) => {
-      if (this.isExcludedQueryParam(key, value)) {
+    url.searchParams.forEach((_value, key) => {
+      if (this.isExcludedQueryParam(key)) {
         keysToDelete.add(key);
       }
     });

--- a/src/event/constants.ts
+++ b/src/event/constants.ts
@@ -21,8 +21,9 @@ const CLICK_ID_PARAMS = [
  * Query parameters that are ALWAYS stripped from forwarded and stored URLs,
  * regardless of consumer configuration, because they carry high-sensitivity
  * secrets that must never reach Formo:
- * - privy_oauth_code:  Privy OAuth authorization code
- * - privy_oauth_state: Privy OAuth CSRF state token
+ * - privy_oauth_code:     Privy OAuth authorization code
+ * - privy_oauth_state:    Privy OAuth CSRF state token
+ * - privy_oauth_provider: Privy OAuth provider identifier
  *
  * Consumers can extend the denylist via `tracking.excludeQueryParams` but
  * cannot remove these built-ins. Matched case-insensitively.
@@ -30,6 +31,7 @@ const CLICK_ID_PARAMS = [
 const DEFAULT_EXCLUDED_QUERY_PARAMS = [
   "privy_oauth_code",
   "privy_oauth_state",
+  "privy_oauth_provider",
 ] as const;
 
 /**

--- a/src/event/constants.ts
+++ b/src/event/constants.ts
@@ -18,6 +18,21 @@ const CLICK_ID_PARAMS = [
 ] as const;
 
 /**
+ * Query parameters that are ALWAYS stripped from forwarded and stored URLs,
+ * regardless of consumer configuration, because they carry high-sensitivity
+ * secrets that must never reach Formo:
+ * - privy_oauth_code:  Privy OAuth authorization code
+ * - privy_oauth_state: Privy OAuth CSRF state token
+ *
+ * Consumers can extend the denylist via `tracking.excludeQueryParams` but
+ * cannot remove these built-ins. Matched case-insensitively.
+ */
+const DEFAULT_EXCLUDED_QUERY_PARAMS = [
+  "privy_oauth_code",
+  "privy_oauth_state",
+] as const;
+
+/**
  * Fields that should be excluded from page event properties parsing
  * These are either:
  * - Already captured in event context (UTM params, referral params, click IDs)
@@ -44,4 +59,10 @@ const PAGE_PROPERTIES_EXCLUDED_FIELDS = new Set<string>([
   'query',
 ]);
 
-export { CHANNEL, VERSION, CLICK_ID_PARAMS, PAGE_PROPERTIES_EXCLUDED_FIELDS };
+export {
+  CHANNEL,
+  VERSION,
+  CLICK_ID_PARAMS,
+  DEFAULT_EXCLUDED_QUERY_PARAMS,
+  PAGE_PROPERTIES_EXCLUDED_FIELDS,
+};

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -126,8 +126,9 @@ export interface TrackingOptions {
   excludeChains?: ChainID[];
   /**
    * Additional query parameters to strip from forwarded and stored URLs, on top
-   * of a built-in always-on denylist (currently `privy_oauth_code` and
-   * `privy_oauth_state`) that cannot be disabled. Excluded params are stripped
+   * of a built-in always-on denylist (currently `privy_oauth_code`,
+   * `privy_oauth_state`, and `privy_oauth_provider`) that cannot be disabled.
+   * Excluded params are stripped
    * from the captured page URL, query string, per-parameter page properties,
    * and referrer before any event is sent. The URL hash/fragment is
    * intentionally left untouched.

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -125,19 +125,28 @@ export interface TrackingOptions {
   excludePaths?: string[];
   excludeChains?: ChainID[];
   /**
-   * Additional query parameter keys to strip from forwarded and stored URLs,
-   * on top of a built-in always-on denylist (currently `privy_oauth_code` and
-   * `privy_oauth_state`) that cannot be disabled. Matched case-insensitively
-   * and stripped from the captured page URL, query string, per-parameter page
-   * properties, and referrer before any event is sent. The URL hash/fragment
-   * is intentionally left untouched.
+   * Additional query parameters to strip from forwarded and stored URLs, on top
+   * of a built-in always-on denylist (currently `privy_oauth_code` and
+   * `privy_oauth_state`) that cannot be disabled. Excluded params are stripped
+   * from the captured page URL, query string, per-parameter page properties,
+   * and referrer before any event is sent. The URL hash/fragment is
+   * intentionally left untouched.
+   *
+   * Accepts either:
+   * - `string[]` — exact key names, matched case-insensitively; or
+   * - a predicate `(key, value) => boolean` returning `true` to drop a
+   *   parameter, for arbitrary logic such as prefix/regex matching on the key
+   *   or matching on the value. The predicate runs in addition to (and cannot
+   *   override) the built-in denylist; if it throws, the error is logged and
+   *   the parameter is kept (the built-ins are still stripped).
    *
    * Mirrors Mixpanel's `property_blacklist` and PostHog's `property_denylist`,
    * scoped here to URL query parameters.
    *
    * @example ["token", "access_token", "email", "signature"]
+   * @example (key, value) => key.startsWith("secret_") || value.length > 256
    */
-  excludeQueryParams?: string[];
+  excludeQueryParams?: string[] | ((key: string, value: string) => boolean);
 }
 
 /**

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -125,14 +125,15 @@ export interface TrackingOptions {
   excludePaths?: string[];
   excludeChains?: ChainID[];
   /**
-   * Query parameter keys that must never be forwarded to or stored by Formo.
-   * Matched case-insensitively and stripped from the captured page URL, query
-   * string, per-parameter page properties, and referrer before any event is
-   * sent. The URL hash/fragment is intentionally left untouched.
+   * Additional query parameter keys to strip from forwarded and stored URLs,
+   * on top of a built-in always-on denylist (currently `privy_oauth_code` and
+   * `privy_oauth_state`) that cannot be disabled. Matched case-insensitively
+   * and stripped from the captured page URL, query string, per-parameter page
+   * properties, and referrer before any event is sent. The URL hash/fragment
+   * is intentionally left untouched.
    *
-   * Opt-in and empty by default (nothing is dropped unless listed), mirroring
-   * Mixpanel's `property_blacklist` and PostHog's `property_denylist` — scoped
-   * here to URL query parameters.
+   * Mirrors Mixpanel's `property_blacklist` and PostHog's `property_denylist`,
+   * scoped here to URL query parameters.
    *
    * @example ["token", "access_token", "email", "signature"]
    */

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -125,29 +125,19 @@ export interface TrackingOptions {
   excludePaths?: string[];
   excludeChains?: ChainID[];
   /**
-   * Additional query parameters to strip from forwarded and stored URLs, on top
-   * of a built-in always-on denylist (currently `privy_oauth_code`,
+   * Additional query parameter names to strip from forwarded and stored URLs,
+   * on top of a built-in always-on denylist (currently `privy_oauth_code`,
    * `privy_oauth_state`, and `privy_oauth_provider`) that cannot be disabled.
-   * Excluded params are stripped
-   * from the captured page URL, query string, per-parameter page properties,
-   * and referrer before any event is sent. The URL hash/fragment is
-   * intentionally left untouched.
-   *
-   * Accepts either:
-   * - `string[]` — exact key names, matched case-insensitively; or
-   * - a predicate `(key, value) => boolean` returning `true` to drop a
-   *   parameter, for arbitrary logic such as prefix/regex matching on the key
-   *   or matching on the value. The predicate runs in addition to (and cannot
-   *   override) the built-in denylist; if it throws, the error is logged and
-   *   the parameter is kept (the built-ins are still stripped).
+   * Matched case-insensitively. Excluded params are stripped from the captured
+   * page URL, query string, per-parameter page properties, and referrer before
+   * any event is sent. The URL hash/fragment is intentionally left untouched.
    *
    * Mirrors Mixpanel's `property_blacklist` and PostHog's `property_denylist`,
    * scoped here to URL query parameters.
    *
    * @example ["token", "access_token", "email", "signature"]
-   * @example (key, value) => key.startsWith("secret_") || value.length > 256
    */
-  excludeQueryParams?: string[] | ((key: string, value: string) => boolean);
+  excludeQueryParams?: string[];
 }
 
 /**

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -124,6 +124,19 @@ export interface TrackingOptions {
   excludeHosts?: string[];
   excludePaths?: string[];
   excludeChains?: ChainID[];
+  /**
+   * Query parameter keys that must never be forwarded to or stored by Formo.
+   * Matched case-insensitively and stripped from the captured page URL, query
+   * string, per-parameter page properties, and referrer before any event is
+   * sent. The URL hash/fragment is intentionally left untouched.
+   *
+   * Opt-in and empty by default (nothing is dropped unless listed), mirroring
+   * Mixpanel's `property_blacklist` and PostHog's `property_denylist` — scoped
+   * here to URL query parameters.
+   *
+   * @example ["token", "access_token", "email", "signature"]
+   */
+  excludeQueryParams?: string[];
 }
 
 /**

--- a/test/lib/event/QueryParamExclusion.spec.ts
+++ b/test/lib/event/QueryParamExclusion.spec.ts
@@ -125,15 +125,17 @@ describe("EventFactory query parameter exclusion", () => {
   describe("built-in always-on denylist", () => {
     it("always strips Privy OAuth params with no configuration", async () => {
       setMockLocation(
-        "https://formo.so/callback?privy_oauth_code=SECRET_CODE&privy_oauth_state=CSRF_TOKEN&foo=bar"
+        "https://formo.so/callback?privy_oauth_code=SECRET_CODE&privy_oauth_state=CSRF_TOKEN&privy_oauth_provider=google&foo=bar"
       );
       const props = await getProps(new EventFactory());
 
       expect(props.url).to.not.contain("SECRET_CODE");
       expect(props.url).to.not.contain("CSRF_TOKEN");
+      expect(props.url).to.not.contain("privy_oauth_provider");
       expect(props.query).to.equal("foo=bar");
       expect(props.privy_oauth_code).to.be.undefined;
       expect(props.privy_oauth_state).to.be.undefined;
+      expect(props.privy_oauth_provider).to.be.undefined;
       expect(props.foo).to.equal("bar");
     });
 
@@ -210,7 +212,7 @@ describe("EventFactory query parameter exclusion", () => {
       const props = await getProps(
         new EventFactory({
           tracking: {
-            excludeQueryParams: (key: string, value: string) =>
+            excludeQueryParams: (_key: string, value: string) =>
               value.startsWith("eyJ"),
           },
         })

--- a/test/lib/event/QueryParamExclusion.spec.ts
+++ b/test/lib/event/QueryParamExclusion.spec.ts
@@ -98,11 +98,11 @@ describe("EventFactory query parameter exclusion", () => {
     if (jsdom) jsdom.window.close();
   });
 
-  function setMockLocation(url: string) {
+  function setMockLocation(url: string, referrer?: string) {
     if (jsdom) jsdom.window.close();
     jsdom = new JSDOM(
       "<!DOCTYPE html><html><head><title>Test Page</title></head><body></body></html>",
-      { url }
+      referrer ? { url, referrer } : { url }
     );
     (global as any).window = jsdom.window;
     (global as any).document = jsdom.window.document;
@@ -110,15 +110,22 @@ describe("EventFactory query parameter exclusion", () => {
     (global as any).globalThis = jsdom.window;
   }
 
+  async function getEvent(
+    factory: EventFactory,
+    properties: Record<string, any> = {}
+  ): Promise<Record<string, any>> {
+    return (await factory.generatePageEvent(
+      properties.category,
+      properties.name,
+      properties
+    )) as unknown as Record<string, any>;
+  }
+
   async function getProps(
     factory: EventFactory,
     properties: Record<string, any> = {}
   ): Promise<Record<string, any>> {
-    const event = await factory.generatePageEvent(
-      properties.category,
-      properties.name,
-      properties
-    );
+    const event = await getEvent(factory, properties);
     return (event.properties as Record<string, any>) || {};
   }
 
@@ -184,6 +191,82 @@ describe("EventFactory query parameter exclusion", () => {
 
       expect(props.url).to.not.contain("ABC");
       expect(props.keep).to.equal("1");
+    });
+  });
+
+  // Excluded params must not leak through the event *context* either — not via
+  // page_url, not via the referrer, and not via the traffic-source extraction
+  // (utm_*, click ids, ref), which parses the URL separately from page props.
+  describe("event context redaction", () => {
+    it("strips excluded params from context.page_url", async () => {
+      setMockLocation(
+        "https://formo.so/page?token=ABC&privy_oauth_code=SECRET&keep=1"
+      );
+      const event = await getEvent(
+        new EventFactory({ tracking: { excludeQueryParams: ["token"] } })
+      );
+
+      expect(event.context.page_url).to.not.contain("ABC");
+      expect(event.context.page_url).to.not.contain("SECRET");
+      expect(event.context.page_url).to.contain("keep=1");
+    });
+
+    it("does not leak an excluded param that is also a traffic-source key", async () => {
+      setMockLocation(
+        "https://formo.so/page?utm_source=secretcampaign&gclid=SECRETCLICK&ref=SECRETREF&utm_medium=email"
+      );
+      const event = await getEvent(
+        new EventFactory({
+          tracking: { excludeQueryParams: ["utm_source", "gclid", "ref"] },
+        })
+      );
+
+      // Excluded traffic-source keys are emptied in context...
+      expect(event.context.utm_source).to.equal("");
+      expect(event.context.gclid).to.equal("");
+      expect(event.context.ref).to.equal("");
+      // ...while non-excluded traffic-source keys still capture normally.
+      expect(event.context.utm_medium).to.equal("email");
+    });
+
+    it("strips excluded params from the external referrer", async () => {
+      setMockLocation(
+        "https://formo.so/page?keep=1",
+        "https://referrer.example/landing?token=SECRETTOKEN&campaign=spring"
+      );
+      const event = await getEvent(
+        new EventFactory({ tracking: { excludeQueryParams: ["token"] } })
+      );
+
+      expect(event.context.referrer).to.not.contain("SECRETTOKEN");
+      expect(event.context.referrer).to.contain("campaign=spring");
+    });
+
+    it("strips the always-on privy defaults from the external referrer", async () => {
+      setMockLocation(
+        "https://formo.so/page?keep=1",
+        "https://referrer.example/oauth?privy_oauth_code=SECRETCODE&ok=1"
+      );
+      const event = await getEvent(new EventFactory());
+
+      expect(event.context.referrer).to.not.contain("SECRETCODE");
+      expect(event.context.referrer).to.contain("ok=1");
+    });
+
+    it("drops a sticky traffic-source value stored under an earlier, looser config", async () => {
+      // First pageview: no exclusion, so gclid is captured and persisted to the
+      // sticky SESSION_TRAFFIC_SOURCE_KEY store.
+      setMockLocation("https://formo.so/page?gclid=OLDCLICK");
+      const first = await getEvent(new EventFactory());
+      expect(first.context.gclid).to.equal("OLDCLICK");
+
+      // Later pageview on a clean URL, now excluding gclid. The stored value
+      // must not resurface in context from session storage.
+      setMockLocation("https://formo.so/page?keep=1");
+      const second = await getEvent(
+        new EventFactory({ tracking: { excludeQueryParams: ["gclid"] } })
+      );
+      expect(second.context.gclid).to.equal("");
     });
   });
 });

--- a/test/lib/event/QueryParamExclusion.spec.ts
+++ b/test/lib/event/QueryParamExclusion.spec.ts
@@ -1,91 +1,276 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
 import { expect } from "chai";
-import "global-jsdom/register";
+import { JSDOM } from "jsdom";
 import { EventFactory } from "../../../src/event/EventFactory";
+import { initStorageManager, session } from "../../../src/storage";
+import { SESSION_TRAFFIC_SOURCE_KEY } from "../../../src/constants";
 
 /**
  * Tests for sensitive query-parameter exclusion in page properties.
  *
- * The built-in denylist (privy_oauth_code, privy_oauth_state) is always
- * stripped regardless of configuration; consumers can add more keys via
- * tracking.excludeQueryParams. Only the query string is redacted — the URL
- * hash/fragment is intentionally left untouched.
+ * Two layers:
+ * - A built-in always-on denylist (privy_oauth_code, privy_oauth_state) that is
+ *   stripped regardless of configuration and cannot be disabled.
+ * - An opt-in `tracking.excludeQueryParams`, accepting either an array of key
+ *   names (case-insensitive) or a predicate `(key, value) => boolean`.
+ *
+ * Only the query string is redacted — the URL hash/fragment is intentionally
+ * left untouched. Excluded params must not appear in `url`, `query`, or the
+ * per-parameter page-property explosion.
  */
 describe("EventFactory query parameter exclusion", () => {
-  const setLocation = (url: string) => {
-    const u = new URL(url);
-    Object.defineProperty(window, "location", {
+  let jsdom: JSDOM;
+
+  beforeEach(() => {
+    jsdom = new JSDOM(
+      "<!DOCTYPE html><html><head><title>Test Page</title></head><body></body></html>",
+      { url: "https://formo.so/" }
+    );
+
+    Object.defineProperty(global, "window", {
+      value: jsdom.window, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "document", {
+      value: jsdom.window.document, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "location", {
+      value: jsdom.window.location, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "globalThis", {
+      value: jsdom.window, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "navigator", {
+      value: jsdom.window.navigator, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "screen", {
+      value: jsdom.window.screen, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "devicePixelRatio", {
+      value: 1, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "innerWidth", {
+      value: 1920, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "innerHeight", {
+      value: 1080, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "Intl", {
       value: {
-        href: u.href,
-        pathname: u.pathname,
-        search: u.search,
-        hash: u.hash,
-        host: u.host,
-        hostname: u.hostname,
-        origin: u.origin,
-        protocol: u.protocol,
+        DateTimeFormat: () => ({
+          resolvedOptions: () => ({ timeZone: "America/New_York" }),
+        }),
       },
-      writable: true,
-      configurable: true,
+      writable: true, configurable: true,
     });
-  };
-
-  it("always strips the built-in Privy OAuth params with no config", async () => {
-    setLocation(
-      "https://example.com/callback?privy_oauth_code=SECRET_CODE&privy_oauth_state=CSRF_TOKEN&foo=bar"
-    );
-    const factory = new EventFactory();
-    const event = await factory.generatePageEvent("cat", "name");
-
-    // Removed from url, query string, and the per-parameter explosion.
-    expect(event.properties?.url).to.not.contain("SECRET_CODE");
-    expect(event.properties?.url).to.not.contain("CSRF_TOKEN");
-    expect(event.properties?.query).to.not.contain("privy_oauth_code");
-    expect(event.properties?.query).to.not.contain("privy_oauth_state");
-    expect(event.properties?.privy_oauth_code).to.be.undefined;
-    expect(event.properties?.privy_oauth_state).to.be.undefined;
-
-    // Benign params are retained.
-    expect(event.properties?.foo).to.equal("bar");
-    expect(event.properties?.query).to.equal("foo=bar");
-  });
-
-  it("matches the built-in params case-insensitively", async () => {
-    setLocation(
-      "https://example.com/callback?PRIVY_OAUTH_CODE=SECRET_CODE&keep=1"
-    );
-    const factory = new EventFactory();
-    const event = await factory.generatePageEvent("cat", "name");
-
-    expect(event.properties?.url).to.not.contain("SECRET_CODE");
-    expect(event.properties?.keep).to.equal("1");
-  });
-
-  it("strips additional params from tracking.excludeQueryParams on top of defaults", async () => {
-    setLocation(
-      "https://example.com/page?token=ABC&privy_oauth_code=SECRET_CODE&page=2"
-    );
-    const factory = new EventFactory({
-      tracking: { excludeQueryParams: ["token"] },
+    Object.defineProperty(global, "localStorage", {
+      value: jsdom.window.localStorage, writable: true, configurable: true,
     });
-    const event = await factory.generatePageEvent("cat", "name");
+    Object.defineProperty(global, "sessionStorage", {
+      value: jsdom.window.sessionStorage, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "crypto", {
+      value: { randomUUID: () => "12345678-1234-1234-1234-123456789abc" },
+      writable: true, configurable: true,
+    });
 
-    expect(event.properties?.url).to.not.contain("ABC");
-    expect(event.properties?.url).to.not.contain("SECRET_CODE");
-    expect(event.properties?.token).to.be.undefined;
-    expect(event.properties?.privy_oauth_code).to.be.undefined;
-    expect(event.properties?.page).to.equal("2");
+    initStorageManager("test-write-key");
+
+    // Clear sticky traffic-source state so each test starts clean.
+    try {
+      session().remove(SESSION_TRAFFIC_SOURCE_KEY);
+    } catch {}
   });
 
-  it("leaves the URL hash/fragment untouched", async () => {
-    setLocation(
-      "https://example.com/callback?privy_oauth_code=SECRET_CODE#privy_oauth_state=HASH_KEPT"
-    );
-    const factory = new EventFactory();
-    const event = await factory.generatePageEvent("cat", "name");
+  afterEach(() => {
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).location;
+    delete (global as any).globalThis;
+    delete (global as any).navigator;
+    delete (global as any).screen;
+    delete (global as any).devicePixelRatio;
+    delete (global as any).innerWidth;
+    delete (global as any).innerHeight;
+    delete (global as any).Intl;
+    delete (global as any).localStorage;
+    delete (global as any).sessionStorage;
+    delete (global as any).crypto;
+    if (jsdom) jsdom.window.close();
+  });
 
-    expect(event.properties?.url).to.not.contain("SECRET_CODE");
-    expect(event.properties?.url).to.contain("#privy_oauth_state=HASH_KEPT");
-    expect(event.properties?.hash).to.equal("#privy_oauth_state=HASH_KEPT");
-    expect(event.properties?.query).to.equal("");
+  function setMockLocation(url: string) {
+    if (jsdom) jsdom.window.close();
+    jsdom = new JSDOM(
+      "<!DOCTYPE html><html><head><title>Test Page</title></head><body></body></html>",
+      { url }
+    );
+    (global as any).window = jsdom.window;
+    (global as any).document = jsdom.window.document;
+    (global as any).location = jsdom.window.location;
+    (global as any).globalThis = jsdom.window;
+  }
+
+  async function getProps(
+    factory: EventFactory,
+    properties: Record<string, any> = {}
+  ): Promise<Record<string, any>> {
+    const event = await factory.generatePageEvent(
+      properties.category,
+      properties.name,
+      properties
+    );
+    return (event.properties as Record<string, any>) || {};
+  }
+
+  describe("built-in always-on denylist", () => {
+    it("always strips Privy OAuth params with no configuration", async () => {
+      setMockLocation(
+        "https://formo.so/callback?privy_oauth_code=SECRET_CODE&privy_oauth_state=CSRF_TOKEN&foo=bar"
+      );
+      const props = await getProps(new EventFactory());
+
+      expect(props.url).to.not.contain("SECRET_CODE");
+      expect(props.url).to.not.contain("CSRF_TOKEN");
+      expect(props.query).to.equal("foo=bar");
+      expect(props.privy_oauth_code).to.be.undefined;
+      expect(props.privy_oauth_state).to.be.undefined;
+      expect(props.foo).to.equal("bar");
+    });
+
+    it("matches built-in params case-insensitively", async () => {
+      setMockLocation("https://formo.so/callback?PRIVY_OAUTH_CODE=SECRET_CODE&keep=1");
+      const props = await getProps(new EventFactory());
+
+      expect(props.url).to.not.contain("SECRET_CODE");
+      expect(props.keep).to.equal("1");
+    });
+
+    it("leaves the URL hash/fragment untouched", async () => {
+      setMockLocation(
+        "https://formo.so/callback?privy_oauth_code=SECRET_CODE#privy_oauth_state=HASH_KEPT"
+      );
+      const props = await getProps(new EventFactory());
+
+      expect(props.url).to.not.contain("SECRET_CODE");
+      expect(props.url).to.contain("#privy_oauth_state=HASH_KEPT");
+      expect(props.hash).to.equal("#privy_oauth_state=HASH_KEPT");
+      expect(props.query).to.equal("");
+    });
+  });
+
+  describe("excludeQueryParams as an array", () => {
+    it("strips configured keys on top of the built-in defaults", async () => {
+      setMockLocation(
+        "https://formo.so/page?token=ABC&privy_oauth_code=SECRET_CODE&page=2"
+      );
+      const props = await getProps(
+        new EventFactory({ tracking: { excludeQueryParams: ["token"] } })
+      );
+
+      expect(props.url).to.not.contain("ABC");
+      expect(props.url).to.not.contain("SECRET_CODE");
+      expect(props.token).to.be.undefined;
+      expect(props.privy_oauth_code).to.be.undefined;
+      expect(props.page).to.equal("2");
+    });
+
+    it("matches configured keys case-insensitively", async () => {
+      setMockLocation("https://formo.so/page?Token=ABC&keep=1");
+      const props = await getProps(
+        new EventFactory({ tracking: { excludeQueryParams: ["token"] } })
+      );
+
+      expect(props.url).to.not.contain("ABC");
+      expect(props.keep).to.equal("1");
+    });
+  });
+
+  describe("excludeQueryParams as a predicate", () => {
+    it("drops parameters by key prefix", async () => {
+      setMockLocation(
+        "https://formo.so/page?secret_token=A&secret_id=B&page=2"
+      );
+      const props = await getProps(
+        new EventFactory({
+          tracking: {
+            excludeQueryParams: (key: string) => key.startsWith("secret_"),
+          },
+        })
+      );
+
+      expect(props.url).to.not.contain("secret_token");
+      expect(props.url).to.not.contain("secret_id");
+      expect(props.secret_token).to.be.undefined;
+      expect(props.secret_id).to.be.undefined;
+      expect(props.page).to.equal("2");
+    });
+
+    it("drops parameters by value, regardless of key name", async () => {
+      setMockLocation("https://formo.so/page?data=eyJhbGciOiJ9&q=hello");
+      const props = await getProps(
+        new EventFactory({
+          tracking: {
+            excludeQueryParams: (key: string, value: string) =>
+              value.startsWith("eyJ"),
+          },
+        })
+      );
+
+      expect(props.url).to.not.contain("eyJhbGciOiJ9");
+      expect(props.data).to.be.undefined;
+      expect(props.q).to.equal("hello");
+    });
+
+    it("passes the key and value to the predicate", async () => {
+      setMockLocation("https://formo.so/page?foo=bar&n=1");
+      const seen: Array<[string, string]> = [];
+      await getProps(
+        new EventFactory({
+          tracking: {
+            excludeQueryParams: (key: string, value: string) => {
+              seen.push([key, value]);
+              return false;
+            },
+          },
+        })
+      );
+
+      expect(seen).to.deep.include(["foo", "bar"]);
+      expect(seen).to.deep.include(["n", "1"]);
+    });
+
+    it("cannot re-enable a built-in default even if the predicate returns false", async () => {
+      setMockLocation("https://formo.so/callback?privy_oauth_code=SECRET_CODE&keep=1");
+      const props = await getProps(
+        new EventFactory({
+          tracking: { excludeQueryParams: () => false },
+        })
+      );
+
+      expect(props.url).to.not.contain("SECRET_CODE");
+      expect(props.privy_oauth_code).to.be.undefined;
+      expect(props.keep).to.equal("1");
+    });
+
+    it("fails open and keeps tracking working when the predicate throws", async () => {
+      setMockLocation(
+        "https://formo.so/callback?privy_oauth_state=CSRF_TOKEN&user=alice"
+      );
+      const props = await getProps(
+        new EventFactory({
+          tracking: {
+            excludeQueryParams: () => {
+              throw new Error("boom");
+            },
+          },
+        })
+      );
+
+      // Built-in default is still stripped; the param the (broken) predicate
+      // would have judged is kept rather than dropping it or throwing.
+      expect(props.url).to.not.contain("CSRF_TOKEN");
+      expect(props.privy_oauth_state).to.be.undefined;
+      expect(props.user).to.equal("alice");
+    });
   });
 });

--- a/test/lib/event/QueryParamExclusion.spec.ts
+++ b/test/lib/event/QueryParamExclusion.spec.ts
@@ -11,8 +11,8 @@ import { SESSION_TRAFFIC_SOURCE_KEY } from "../../../src/constants";
  * Two layers:
  * - A built-in always-on denylist (privy_oauth_code, privy_oauth_state) that is
  *   stripped regardless of configuration and cannot be disabled.
- * - An opt-in `tracking.excludeQueryParams`, accepting either an array of key
- *   names (case-insensitive) or a predicate `(key, value) => boolean`.
+ * - An opt-in `tracking.excludeQueryParams` array of key names
+ *   (case-insensitive).
  *
  * Only the query string is redacted — the URL hash/fragment is intentionally
  * left untouched. Excluded params must not appear in `url`, `query`, or the
@@ -184,95 +184,6 @@ describe("EventFactory query parameter exclusion", () => {
 
       expect(props.url).to.not.contain("ABC");
       expect(props.keep).to.equal("1");
-    });
-  });
-
-  describe("excludeQueryParams as a predicate", () => {
-    it("drops parameters by key prefix", async () => {
-      setMockLocation(
-        "https://formo.so/page?secret_token=A&secret_id=B&page=2"
-      );
-      const props = await getProps(
-        new EventFactory({
-          tracking: {
-            excludeQueryParams: (key: string) => key.startsWith("secret_"),
-          },
-        })
-      );
-
-      expect(props.url).to.not.contain("secret_token");
-      expect(props.url).to.not.contain("secret_id");
-      expect(props.secret_token).to.be.undefined;
-      expect(props.secret_id).to.be.undefined;
-      expect(props.page).to.equal("2");
-    });
-
-    it("drops parameters by value, regardless of key name", async () => {
-      setMockLocation("https://formo.so/page?data=eyJhbGciOiJ9&q=hello");
-      const props = await getProps(
-        new EventFactory({
-          tracking: {
-            excludeQueryParams: (_key: string, value: string) =>
-              value.startsWith("eyJ"),
-          },
-        })
-      );
-
-      expect(props.url).to.not.contain("eyJhbGciOiJ9");
-      expect(props.data).to.be.undefined;
-      expect(props.q).to.equal("hello");
-    });
-
-    it("passes the key and value to the predicate", async () => {
-      setMockLocation("https://formo.so/page?foo=bar&n=1");
-      const seen: Array<[string, string]> = [];
-      await getProps(
-        new EventFactory({
-          tracking: {
-            excludeQueryParams: (key: string, value: string) => {
-              seen.push([key, value]);
-              return false;
-            },
-          },
-        })
-      );
-
-      expect(seen).to.deep.include(["foo", "bar"]);
-      expect(seen).to.deep.include(["n", "1"]);
-    });
-
-    it("cannot re-enable a built-in default even if the predicate returns false", async () => {
-      setMockLocation("https://formo.so/callback?privy_oauth_code=SECRET_CODE&keep=1");
-      const props = await getProps(
-        new EventFactory({
-          tracking: { excludeQueryParams: () => false },
-        })
-      );
-
-      expect(props.url).to.not.contain("SECRET_CODE");
-      expect(props.privy_oauth_code).to.be.undefined;
-      expect(props.keep).to.equal("1");
-    });
-
-    it("fails open and keeps tracking working when the predicate throws", async () => {
-      setMockLocation(
-        "https://formo.so/callback?privy_oauth_state=CSRF_TOKEN&user=alice"
-      );
-      const props = await getProps(
-        new EventFactory({
-          tracking: {
-            excludeQueryParams: () => {
-              throw new Error("boom");
-            },
-          },
-        })
-      );
-
-      // Built-in default is still stripped; the param the (broken) predicate
-      // would have judged is kept rather than dropping it or throwing.
-      expect(props.url).to.not.contain("CSRF_TOKEN");
-      expect(props.privy_oauth_state).to.be.undefined;
-      expect(props.user).to.equal("alice");
     });
   });
 });

--- a/test/lib/event/QueryParamExclusion.spec.ts
+++ b/test/lib/event/QueryParamExclusion.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import "global-jsdom/register";
+import { EventFactory } from "../../../src/event/EventFactory";
+
+/**
+ * Tests for sensitive query-parameter exclusion in page properties.
+ *
+ * The built-in denylist (privy_oauth_code, privy_oauth_state) is always
+ * stripped regardless of configuration; consumers can add more keys via
+ * tracking.excludeQueryParams. Only the query string is redacted — the URL
+ * hash/fragment is intentionally left untouched.
+ */
+describe("EventFactory query parameter exclusion", () => {
+  const setLocation = (url: string) => {
+    const u = new URL(url);
+    Object.defineProperty(window, "location", {
+      value: {
+        href: u.href,
+        pathname: u.pathname,
+        search: u.search,
+        hash: u.hash,
+        host: u.host,
+        hostname: u.hostname,
+        origin: u.origin,
+        protocol: u.protocol,
+      },
+      writable: true,
+      configurable: true,
+    });
+  };
+
+  it("always strips the built-in Privy OAuth params with no config", async () => {
+    setLocation(
+      "https://example.com/callback?privy_oauth_code=SECRET_CODE&privy_oauth_state=CSRF_TOKEN&foo=bar"
+    );
+    const factory = new EventFactory();
+    const event = await factory.generatePageEvent("cat", "name");
+
+    // Removed from url, query string, and the per-parameter explosion.
+    expect(event.properties?.url).to.not.contain("SECRET_CODE");
+    expect(event.properties?.url).to.not.contain("CSRF_TOKEN");
+    expect(event.properties?.query).to.not.contain("privy_oauth_code");
+    expect(event.properties?.query).to.not.contain("privy_oauth_state");
+    expect(event.properties?.privy_oauth_code).to.be.undefined;
+    expect(event.properties?.privy_oauth_state).to.be.undefined;
+
+    // Benign params are retained.
+    expect(event.properties?.foo).to.equal("bar");
+    expect(event.properties?.query).to.equal("foo=bar");
+  });
+
+  it("matches the built-in params case-insensitively", async () => {
+    setLocation(
+      "https://example.com/callback?PRIVY_OAUTH_CODE=SECRET_CODE&keep=1"
+    );
+    const factory = new EventFactory();
+    const event = await factory.generatePageEvent("cat", "name");
+
+    expect(event.properties?.url).to.not.contain("SECRET_CODE");
+    expect(event.properties?.keep).to.equal("1");
+  });
+
+  it("strips additional params from tracking.excludeQueryParams on top of defaults", async () => {
+    setLocation(
+      "https://example.com/page?token=ABC&privy_oauth_code=SECRET_CODE&page=2"
+    );
+    const factory = new EventFactory({
+      tracking: { excludeQueryParams: ["token"] },
+    });
+    const event = await factory.generatePageEvent("cat", "name");
+
+    expect(event.properties?.url).to.not.contain("ABC");
+    expect(event.properties?.url).to.not.contain("SECRET_CODE");
+    expect(event.properties?.token).to.be.undefined;
+    expect(event.properties?.privy_oauth_code).to.be.undefined;
+    expect(event.properties?.page).to.equal("2");
+  });
+
+  it("leaves the URL hash/fragment untouched", async () => {
+    setLocation(
+      "https://example.com/callback?privy_oauth_code=SECRET_CODE#privy_oauth_state=HASH_KEPT"
+    );
+    const factory = new EventFactory();
+    const event = await factory.generatePageEvent("cat", "name");
+
+    expect(event.properties?.url).to.not.contain("SECRET_CODE");
+    expect(event.properties?.url).to.contain("#privy_oauth_state=HASH_KEPT");
+    expect(event.properties?.hash).to.equal("#privy_oauth_state=HASH_KEPT");
+    expect(event.properties?.query).to.equal("");
+  });
+});


### PR DESCRIPTION
> TODO: fix unverified commits, use signed commits



## Summary
Add support for excluding sensitive query parameters from being captured and forwarded by the Formo SDK. This allows users to opt-in to stripping specified query parameters (e.g., tokens, API keys, emails) from URLs before they are stored or sent in events.

## Key Changes
- **New configuration option**: Added `excludeQueryParams` to `TrackingOptions` interface, allowing users to specify query parameter keys that should be redacted (matched case-insensitively)
- **Query parameter redaction**: Implemented `redactUrl()` and `redactQueryParams()` methods to strip excluded parameters from URLs
- **Comprehensive coverage**: Redaction is applied to:
  - Page URL (`page_url`)
  - Referrer URL (`referrer`)
  - Query string property (`query`)
  - Individual query parameter properties (per-parameter explosion)
- **Initialization**: Constructor now processes the `excludeQueryParams` configuration and stores normalized (lowercased) keys in a `Set` for efficient lookup
- **Safe parsing**: Redaction gracefully handles unparseable URLs by returning them unchanged

## Implementation Details
- Query parameters are normalized to lowercase for case-insensitive matching, consistent with URL standards
- The URL hash/fragment is intentionally left untouched during redaction
- Redaction happens early in the event creation pipeline to prevent sensitive data from leaking through any capture mechanism
- Performance optimization: Early return when no parameters are excluded or URL cannot be parsed
- The redacted URL object is reused throughout event creation to avoid redundant parsing

https://claude.ai/code/session_013aqUKJypMpSgJuytLLHnjq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782634654&installation_id=130740768&pr_number=273&repository=getformo%2Fsdk&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fsdk%2Fpull%2F273&signature=25cf24947f0d8f69e2332eaa601c6a985aa5ca6b708f280402452d0100ce0e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->