### PR TITLE
Fix cross-flush dedup to prevent duplicate sends with same message_id

### DIFF
--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -155,16 +155,36 @@ export class EventQueue implements IEventQueue {
   /**
    * Drop all queued data and cancel the flush timer. Called on consent
    * withdrawal / SDK teardown so nothing buffered can be sent later.
+   *
+   * Dedup state is NOT wiped wholesale. Events that are still in flight
+   * (spliced into a request that may yet succeed) keep their seenMessageIds
+   * entry: if such a request lands, a re-enqueue of the same event within
+   * the TTL must still be rejected, otherwise we re-send the same message_id
+   * with a fresh sent_at — the exact regression this map guards against. The
+   * in-flight sendBatches loop still resolves those entries normally (keep
+   * seen on success; delete seen on failure so the caller can retry).
+   *
+   * We forget ids that never left the queue entirely, so genuinely un-sent
+   * events can be re-emitted after a re-opt-in. And we drop ALL unackedIds:
+   * the in-flight entries are deliberately demoted to plain seen entries so
+   * they age out under the normal TTL/cap. Keeping them unacked would pin
+   * them forever if the request never settles (pruneSeenMessageIds refuses
+   * to evict unacked ids), leaking memory and indefinitely suppressing a
+   * legitimately-new re-emission.
    */
   clear(): void {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    for (const item of this.queue) {
+      this.seenMessageIds.delete(item.message.message_id);
+    }
+    // In-flight ids stay in seenMessageIds (deduped until the TTL prunes
+    // them); only the unacked protection is released so they cannot leak.
+    this.unackedIds.clear();
     this.queue = [];
     this.queueByteSize = 0;
-    this.seenMessageIds.clear();
-    this.unackedIds.clear();
   }
 
   async enqueue(event: IFormoEvent, callback?: (...args: any) => void) {
@@ -252,6 +272,16 @@ export class EventQueue implements IEventQueue {
       // before the keepalive fetch for the remaining items is dispatched.
       if (!drainAll) {
         await this.pendingFlush;
+        // Consent can be withdrawn while we were awaiting the in-flight
+        // flush (split batches / retry backoff span seconds). Re-gate
+        // before draining: sendBatches would drop these as skipped anyway,
+        // but re-checking here avoids the wasted splice and keeps the
+        // post-withdrawal "send nothing" semantics explicit.
+        if (this.canSend && !this.canSend()) {
+          this.clear();
+          callback();
+          return Promise.resolve();
+        }
       }
     }
 

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -156,33 +156,40 @@ export class EventQueue implements IEventQueue {
    * Drop all queued data and cancel the flush timer. Called on consent
    * withdrawal / SDK teardown so nothing buffered can be sent later.
    *
-   * Dedup state is NOT wiped wholesale. Events that are still in flight
-   * (spliced into a request that may yet succeed) keep their seenMessageIds
-   * entry: if such a request lands, a re-enqueue of the same event within
-   * the TTL must still be rejected, otherwise we re-send the same message_id
-   * with a fresh sent_at — the exact regression this map guards against. The
-   * in-flight sendBatches loop still resolves those entries normally (keep
-   * seen on success; delete seen on failure so the caller can retry).
+   * Dedup state is NOT wiped wholesale. We forget only ids that never left
+   * the queue (still buffered, never sent) so genuinely un-sent events can be
+   * re-emitted after a re-opt-in. Ids that are already in flight — spliced
+   * into a request that may yet succeed — are left FULLY intact: both their
+   * seenMessageIds entry and their unackedIds protection.
    *
-   * We forget ids that never left the queue entirely, so genuinely un-sent
-   * events can be re-emitted after a re-opt-in. And we drop ALL unackedIds:
-   * the in-flight entries are deliberately demoted to plain seen entries so
-   * they age out under the normal TTL/cap. Keeping them unacked would pin
-   * them forever if the request never settles (pruneSeenMessageIds refuses
-   * to evict unacked ids), leaking memory and indefinitely suppressing a
-   * legitimately-new re-emission.
+   * Leaving the in-flight ids untouched makes the outstanding sendBatches
+   * handlers the sole owner of that state, which is what keeps clear() race-
+   * free:
+   *   - The seenMessageIds entry preserves cross-flush dedup if the request
+   *     lands (re-send of the same message_id with a fresh sent_at is the
+   *     regression this map guards against).
+   *   - Because the id stays in seenMessageIds, a competing re-enqueue of the
+   *     same message_id is still rejected, so no second "generation" of the
+   *     id can form for a stale success/failure handler to later clobber.
+   *   - Because unackedIds still shields it from TTL/cap eviction, the entry
+   *     survives until the request settles, so a slow delivery can still be
+   *     anchored to ack time on success.
+   * The handlers drop unackedIds on settle (success and failure both), so the
+   * protection is released as soon as the request resolves — an id is only
+   * "pinned" for as long as its request is genuinely outstanding.
    */
   clear(): void {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    // Queued ids are never simultaneously in flight (dedup rejects a
+    // re-enqueue while the original id is still tracked), so this forgets
+    // exactly the never-sent set and leaves in-flight ids alone.
     for (const item of this.queue) {
       this.seenMessageIds.delete(item.message.message_id);
+      this.unackedIds.delete(item.message.message_id);
     }
-    // In-flight ids stay in seenMessageIds (deduped until the TTL prunes
-    // them); only the unacked protection is released so they cannot leak.
-    this.unackedIds.clear();
     this.queue = [];
     this.queueByteSize = 0;
   }

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -379,12 +379,25 @@ export class EventQueue implements IEventQueue {
   private async sendBatches(batches: Batch[], allData: IFormoEventFlushPayload[]): Promise<Error | undefined> {
     let firstError: Error | undefined;
 
-    for (const batch of batches) {
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i];
       // Consent can be withdrawn while a flush is already in flight:
       // batches were spliced before opt-out, and split batches / retry
       // backoff span seconds. Re-check before every send and abandon
-      // the remaining batches if consent was revoked mid-flush.
-      if (this.canSend && !this.canSend()) break;
+      // the remaining batches if consent was revoked mid-flush. Clear
+      // the dedup state for all skipped items — otherwise the unacked
+      // markers leak forever (pruneSeenMessageIds protects unacked
+      // entries) and a re-opt-in would silently dedup-drop the same
+      // events. Items that were never sent are not "delivered duplicates."
+      if (this.canSend && !this.canSend()) {
+        for (let j = i; j < batches.length; j++) {
+          batches[j].items.forEach((item) => {
+            this.unackedIds.delete(item.message.message_id);
+            this.seenMessageIds.delete(item.message.message_id);
+          });
+        }
+        break;
+      }
       try {
         const body = JSON.stringify(batch.data);
         const response = await fetch(`${this.apiHost}`, {

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -68,6 +68,18 @@ const DEFAULT_FLUSH_INTERVAL = 1_000 * 30; // 1 MINUTE
 const MAX_FLUSH_INTERVAL = 1_000 * 300; // 5 MINUTES
 const MIN_FLUSH_INTERVAL = 1_000 * 10; // 10 SECONDS
 
+// message_id is computed from the event payload + original_timestamp rounded
+// to the minute (toDateHourMinute), so two identical events emitted within
+// the same UTC minute hash to the same id. Within this window a re-enqueue
+// of the same event must be rejected even if the previous one was already
+// flushed — otherwise the server sees the same message_id with a fresh
+// sent_at on every subsequent flush. The TTL is wider than the rounding
+// granularity plus reasonable clock slop so the rejection is reliable, and
+// the entry count is capped to keep memory bounded if a misbehaving caller
+// floods unique ids.
+const DEDUP_TTL_MS = 5 * 60 * 1_000; // 5 minutes
+const MAX_DEDUP_ENTRIES = 1_000;
+
 export class EventQueue implements IEventQueue {
   private writeKey: string;
   private apiHost: string;
@@ -81,7 +93,10 @@ export class EventQueue implements IEventQueue {
   private errorHandler: any;
   private retryCount: number;
   private pendingFlush: Promise<any> | null;
-  private payloadHashes: Set<string> = new Set();
+  // Insertion-ordered id → first-seen timestamp. Survives across flushes so
+  // a re-enqueue of the same event within DEDUP_TTL_MS is rejected even
+  // after the previous instance was already sent. Pruned lazily on enqueue.
+  private seenMessageIds: Map<string, number> = new Map();
   private canSend?: () => boolean;
 
   constructor(writeKey: string, options: Options) {
@@ -141,7 +156,7 @@ export class EventQueue implements IEventQueue {
     }
     this.queue = [];
     this.queueByteSize = 0;
-    this.payloadHashes.clear();
+    this.seenMessageIds.clear();
   }
 
   async enqueue(event: IFormoEvent, callback?: (...args: any) => void) {
@@ -233,11 +248,19 @@ export class EventQueue implements IEventQueue {
 
     const items = this.queue.splice(0, drainAll ? this.queue.length : this.flushAt);
 
-    // Only remove hashes for flushed items so duplicate detection remains
-    // active for events still in the queue. Also decrement the running
-    // byte total by exactly what left the queue.
+    // A concurrent flush awaiting pendingFlush may resume here after the
+    // earlier flush already drained the queue, leaving us with nothing to
+    // send. Bail out instead of POSTing an empty array.
+    if (items.length === 0) {
+      callback();
+      return Promise.resolve();
+    }
+
+    // Decrement the running byte total by exactly what left the queue.
+    // Keep entries in seenMessageIds so a re-enqueue of the same event
+    // within the dedup TTL is still rejected after the flush — that's the
+    // re-send vector the symptom (same message_id, varying sent_at) maps to.
     for (const item of items) {
-      this.payloadHashes.delete(item.message.message_id);
       this.queueByteSize -= item.byteSize;
     }
     // Re-anchor to the exact invariant when the queue empties, so any
@@ -397,11 +420,35 @@ export class EventQueue implements IEventQueue {
   }
 
   private isDuplicate(eventId: string) {
-    // check if exists a message with identical payload within 1 minute
-    if (this.payloadHashes.has(eventId)) return true;
-
-    this.payloadHashes.add(eventId);
+    this.pruneSeenMessageIds();
+    if (this.seenMessageIds.has(eventId)) return true;
+    this.seenMessageIds.set(eventId, Date.now());
     return false;
+  }
+
+  /**
+   * Drop expired ids and cap the map size. forEach instead of for-of so this
+   * compiles cleanly under target es5 without downlevelIteration. Bounded by
+   * MAX_DEDUP_ENTRIES so a misbehaving caller can't blow up memory.
+   */
+  private pruneSeenMessageIds(): void {
+    const now = Date.now();
+    const expired: string[] = [];
+    this.seenMessageIds.forEach((ts, id) => {
+      if (now - ts > DEDUP_TTL_MS) expired.push(id);
+    });
+    expired.forEach((id) => this.seenMessageIds.delete(id));
+
+    // Bounded safety net for a misbehaving caller — evict oldest first
+    // (insertion order). Only iterates if we're actually over the cap.
+    if (this.seenMessageIds.size > MAX_DEDUP_ENTRIES) {
+      const dropCount = this.seenMessageIds.size - MAX_DEDUP_ENTRIES;
+      const dropKeys: string[] = [];
+      this.seenMessageIds.forEach((_ts, id) => {
+        if (dropKeys.length < dropCount) dropKeys.push(id);
+      });
+      dropKeys.forEach((id) => this.seenMessageIds.delete(id));
+    }
   }
 
   private onPageLeave = (callback: (isAccessible: boolean) => void) => {

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -427,27 +427,35 @@ export class EventQueue implements IEventQueue {
   }
 
   /**
-   * Drop expired ids and cap the map size. forEach instead of for-of so this
-   * compiles cleanly under target es5 without downlevelIteration. Bounded by
-   * MAX_DEDUP_ENTRIES so a misbehaving caller can't blow up memory.
+   * Drop expired ids and cap the map size. Map iteration is insertion-order,
+   * so once we hit a non-expired entry every later entry is also fresher —
+   * stop scanning then. Uses Map.prototype.entries/keys directly with
+   * .next() so this compiles cleanly under target es5 without needing
+   * downlevelIteration. Bounded by MAX_DEDUP_ENTRIES as a safety net.
    */
   private pruneSeenMessageIds(): void {
     const now = Date.now();
-    const expired: string[] = [];
-    this.seenMessageIds.forEach((ts, id) => {
-      if (now - ts > DEDUP_TTL_MS) expired.push(id);
-    });
-    expired.forEach((id) => this.seenMessageIds.delete(id));
+    const iter = this.seenMessageIds.entries();
+    let next = iter.next();
+    while (!next.done) {
+      const id = next.value[0];
+      const ts = next.value[1];
+      if (now - ts > DEDUP_TTL_MS) {
+        this.seenMessageIds.delete(id);
+        next = iter.next();
+      } else {
+        break;
+      }
+    }
 
-    // Bounded safety net for a misbehaving caller — evict oldest first
-    // (insertion order). Only iterates if we're actually over the cap.
     if (this.seenMessageIds.size > MAX_DEDUP_ENTRIES) {
       const dropCount = this.seenMessageIds.size - MAX_DEDUP_ENTRIES;
-      const dropKeys: string[] = [];
-      this.seenMessageIds.forEach((_ts, id) => {
-        if (dropKeys.length < dropCount) dropKeys.push(id);
-      });
-      dropKeys.forEach((id) => this.seenMessageIds.delete(id));
+      const keyIter = this.seenMessageIds.keys();
+      for (let i = 0; i < dropCount; i++) {
+        const k = keyIter.next();
+        if (k.done) break;
+        this.seenMessageIds.delete(k.value);
+      }
     }
   }
 

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -414,10 +414,23 @@ export class EventQueue implements IEventQueue {
           error.response = response;
           throw error;
         }
-        // Delivered. Drop the unacked marker but keep the seenMessageIds
-        // entry so a re-enqueue within DEDUP_TTL_MS is still rejected.
+        // Delivered. Drop the unacked marker and refresh the dedup entry's
+        // timestamp to ack time. While queued/in-flight the entry is kept
+        // alive by unackedIds, but it still carries the original enqueue
+        // time; if delivery was delayed past DEDUP_TTL_MS (long
+        // flushInterval, throttled background-tab timers, slow flush), the
+        // next enqueue of the same id would prune it as expired and re-send
+        // a duplicate. Anchoring the TTL to delivery time preserves the
+        // cross-flush dedup guarantee. delete+set re-inserts at the tail so
+        // seenMessageIds stays ordered by timestamp for the early-break
+        // prune; the delete() return guards against a concurrent clear().
+        const ackTime = Date.now();
         batch.items.forEach((item) => {
-          this.unackedIds.delete(item.message.message_id);
+          const id = item.message.message_id;
+          this.unackedIds.delete(id);
+          if (this.seenMessageIds.delete(id)) {
+            this.seenMessageIds.set(id, ackTime);
+          }
           safeCall(item.callback, undefined, item.message, allData);
         });
       } catch (err: any) {

--- a/src/queue/EventQueue.ts
+++ b/src/queue/EventQueue.ts
@@ -97,6 +97,13 @@ export class EventQueue implements IEventQueue {
   // a re-enqueue of the same event within DEDUP_TTL_MS is rejected even
   // after the previous instance was already sent. Pruned lazily on enqueue.
   private seenMessageIds: Map<string, number> = new Map();
+  // Ids of events whose ack hasn't returned — either still buffered in
+  // this.queue or in flight via sendBatches. These must be protected from
+  // TTL/cap eviction in seenMessageIds; otherwise a duplicate enqueue that
+  // slips past dedup while the original is still in transit can cause both
+  // copies to reach the server. Removed on send success; on send failure,
+  // the seenMessageIds entry is removed too so the caller can retry.
+  private unackedIds: Set<string> = new Set();
   private canSend?: () => boolean;
 
   constructor(writeKey: string, options: Options) {
@@ -157,6 +164,7 @@ export class EventQueue implements IEventQueue {
     this.queue = [];
     this.queueByteSize = 0;
     this.seenMessageIds.clear();
+    this.unackedIds.clear();
   }
 
   async enqueue(event: IFormoEvent, callback?: (...args: any) => void) {
@@ -191,6 +199,7 @@ export class EventQueue implements IEventQueue {
     }).length;
     this.queue.push(queueItem);
     this.queueByteSize += queueItem.byteSize;
+    this.unackedIds.add(message_id);
 
     logger.log(
       `Event enqueued: ${getActionDescriptor(event.type, event.properties)}`
@@ -392,10 +401,23 @@ export class EventQueue implements IEventQueue {
           error.response = response;
           throw error;
         }
-        batch.items.forEach(({ message, callback: cb }) => safeCall(cb, undefined, message, allData));
+        // Delivered. Drop the unacked marker but keep the seenMessageIds
+        // entry so a re-enqueue within DEDUP_TTL_MS is still rejected.
+        batch.items.forEach((item) => {
+          this.unackedIds.delete(item.message.message_id);
+          safeCall(item.callback, undefined, item.message, allData);
+        });
       } catch (err: any) {
         firstError = firstError || err;
-        batch.items.forEach(({ message, callback: cb }) => safeCall(cb, err, message, allData));
+        // Delivery failed (retries exhausted). Drop both the unacked
+        // marker and the seenMessageIds entry so the per-item error
+        // callback can re-enqueue without being silently dedup'd —
+        // otherwise a transient network blip becomes guaranteed loss.
+        batch.items.forEach((item) => {
+          this.unackedIds.delete(item.message.message_id);
+          this.seenMessageIds.delete(item.message.message_id);
+          safeCall(item.callback, err, item.message, allData);
+        });
       }
     }
 
@@ -432,6 +454,11 @@ export class EventQueue implements IEventQueue {
    * stop scanning then. Uses Map.prototype.entries/keys directly with
    * .next() so this compiles cleanly under target es5 without needing
    * downlevelIteration. Bounded by MAX_DEDUP_ENTRIES as a safety net.
+   *
+   * Ids in unackedIds (still queued or in flight) are skipped by both the
+   * TTL pass and the cap pass — evicting them would re-open the dedup
+   * window against a duplicate enqueue while the original is still in
+   * transit, which is exactly the regression we're guarding against.
    */
   private pruneSeenMessageIds(): void {
     const now = Date.now();
@@ -441,7 +468,9 @@ export class EventQueue implements IEventQueue {
       const id = next.value[0];
       const ts = next.value[1];
       if (now - ts > DEDUP_TTL_MS) {
-        this.seenMessageIds.delete(id);
+        if (!this.unackedIds.has(id)) {
+          this.seenMessageIds.delete(id);
+        }
         next = iter.next();
       } else {
         break;
@@ -451,10 +480,13 @@ export class EventQueue implements IEventQueue {
     if (this.seenMessageIds.size > MAX_DEDUP_ENTRIES) {
       const dropCount = this.seenMessageIds.size - MAX_DEDUP_ENTRIES;
       const keyIter = this.seenMessageIds.keys();
-      for (let i = 0; i < dropCount; i++) {
+      let dropped = 0;
+      while (dropped < dropCount) {
         const k = keyIter.next();
         if (k.done) break;
+        if (this.unackedIds.has(k.value)) continue;
         this.seenMessageIds.delete(k.value);
+        dropped++;
       }
     }
   }

--- a/test/lib/queue/EventQueue.spec.ts
+++ b/test/lib/queue/EventQueue.spec.ts
@@ -72,6 +72,39 @@ describe("EventQueue", () => {
     });
   }
 
+  /**
+   * Override crypto.subtle.digest with a deterministic, content-sensitive
+   * hash so generateMessageId actually reflects the event payload + rounded
+   * timestamp (the default mock returns a fixed buffer for every input).
+   */
+  function useContentHashes() {
+    Object.defineProperty(global, "crypto", {
+      value: {
+        subtle: {
+          digest: async (_algorithm: string, data: ArrayBuffer) => {
+            const bytes = new Uint8Array(data);
+            // FNV-1a over the bytes, then expand the 32-bit hash into 32
+            // bytes via an LCG so distinct inputs map to distinct buffers.
+            let h = 0x811c9dc5 >>> 0;
+            for (let i = 0; i < bytes.length; i++) {
+              h = Math.imul(h ^ bytes[i], 0x01000193) >>> 0;
+            }
+            const out = new Uint8Array(32);
+            let s = h >>> 0;
+            for (let i = 0; i < 32; i++) {
+              s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+              out[i] = s & 0xff;
+            }
+            return out.buffer;
+          },
+        },
+        randomUUID: () => "12345678-1234-1234-1234-123456789abc",
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
   /** Enqueue multiple large (~10KB each) events to exceed the 64KB keepalive limit. */
   async function enqueueLargeEvents(queue: EventQueue, count = 8, cb?: sinon.SinonSpy) {
     const largeProps: Record<string, string> = {};
@@ -1082,6 +1115,282 @@ describe("EventQueue", () => {
       // Only one real POST — no empty `[]` body from the second flush
       // resuming after the queue was drained.
       expect(fetchStub.callCount).to.equal(1);
+    });
+
+    it("clear() keeps dedup state for in-flight events so a delivered event is not re-sent", async () => {
+      // Regression: clear() used to wipe seenMessageIds/unackedIds wholesale,
+      // including ids already spliced into an in-flight request. If that
+      // request then succeeds, the event reached the server — but the wiped
+      // dedup entry let a same-minute re-enqueue through, re-sending the same
+      // message_id with a fresh sent_at (the exact symptom this guards).
+      let resolveFirst: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        })
+      );
+      fetchStub.resolves(makeResponse(200, "OK"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      const first = eventQueue.flush(); // event spliced, fetch in flight
+
+      // Consent withdrawal / teardown clears the queue while the request is
+      // still in flight.
+      eventQueue.clear();
+
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      const unacked = (eventQueue as unknown as {
+        unackedIds: Set<string>;
+      }).unackedIds;
+      // In-flight id is kept in seenMessageIds (so it stays deduped) but the
+      // unacked marker is released so it can't be pinned forever if the
+      // request never settles.
+      expect(seen.size, "in-flight id retained for dedup").to.equal(1);
+      expect(
+        unacked.size,
+        "unacked released on clear() so prune can reclaim it"
+      ).to.equal(0);
+
+      // The in-flight request lands successfully — the event is on the server.
+      resolveFirst(makeResponse(200, "OK"));
+      await first;
+
+      // Re-enqueue the same event within the dedup TTL: it must be rejected,
+      // because the delivered event's id is still tracked.
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+
+      expect(
+        fetchStub.callCount,
+        "delivered in-flight event not re-sent after clear()"
+      ).to.equal(1);
+
+      // After the TTL elapses the preserved id is prunable (not pinned by
+      // unacked), so the same event becomes a legitimately-new emission.
+      clock.tick(6 * 60 * 1000);
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(
+        fetchStub.callCount,
+        "post-TTL re-emission allowed (no permanent suppression)"
+      ).to.equal(2);
+    });
+
+    it("clear() still forgets purely-queued (never-sent) events so they can be re-emitted", async () => {
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      // Buffer an event but never flush it, then clear before anything sends.
+      await eventQueue.enqueue(createMockEvent());
+      eventQueue.clear();
+
+      // The same event is now a legitimately new emission (it never reached
+      // the server) and must go through on the next flush.
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+
+      expect(
+        fetchStub.callCount,
+        "queued-then-cleared event is re-emittable"
+      ).to.equal(1);
+    });
+
+    it("re-checks consent after awaiting an in-flight flush and sends nothing if revoked", async () => {
+      // A second flush passes the initial consent gate, then awaits the
+      // in-flight flush. If consent is withdrawn during that await, the
+      // resumed flush must not splice-and-send the buffered items.
+      useUniqueCryptoHashes();
+      let allowed = true;
+      let resolveFirst: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        })
+      );
+      fetchStub.resolves(makeResponse(200, "OK"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+        canSend: () => allowed,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      const first = eventQueue.flush(); // first batch in flight
+
+      // Buffer another event, then start a second flush that awaits the
+      // in-flight one.
+      await eventQueue.enqueue(createMockEvent());
+      const second = eventQueue.flush();
+
+      // Consent revoked while the second flush is parked on `await
+      // pendingFlush`.
+      allowed = false;
+      resolveFirst(makeResponse(200, "OK"));
+      await Promise.all([first, second]);
+
+      // Only the first (pre-revoke) batch was sent; the second flush re-gated
+      // after the await and sent nothing.
+      expect(
+        fetchStub.callCount,
+        "post-revoke flush sends nothing"
+      ).to.equal(1);
+    });
+
+    it("TTL prune does not evict an expired id that is still in flight", async () => {
+      // An id stays unacked while its request is in flight. Even once it is
+      // older than the TTL, pruneSeenMessageIds must skip it — evicting it
+      // would re-open the dedup window against a duplicate enqueue while the
+      // original may still land. (Covers the TTL pass's unacked-skip branch;
+      // the cap pass's skip is covered separately.)
+      let resolveFirst: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        })
+      );
+      fetchStub.resolves(makeResponse(200, "OK"));
+      useUniqueCryptoHashes();
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      const first = eventQueue.flush(); // spliced, request in flight => unacked
+
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      const unacked = (eventQueue as unknown as {
+        unackedIds: Set<string>;
+      }).unackedIds;
+      const inflightId = Array.from(unacked)[0];
+      expect(seen.has(inflightId), "in-flight id tracked").to.be.true;
+
+      // Age the in-flight id well past the TTL, then trigger a prune via a
+      // fresh (unique) enqueue.
+      clock.tick(6 * 60 * 1000);
+      await eventQueue.enqueue(
+        createMockEvent({ properties: { trigger: "prune" } })
+      );
+
+      expect(
+        seen.has(inflightId),
+        "expired in-flight id NOT evicted (protected by unacked)"
+      ).to.be.true;
+      expect(unacked.has(inflightId), "still unacked").to.be.true;
+
+      resolveFirst(makeResponse(200, "OK"));
+      await first;
+    });
+
+    it("TTL prune drops leading expired ids but stops at the first still-fresh id", async () => {
+      useUniqueCryptoHashes();
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+
+      // Event A at T0 (flushed -> acked, lives only in seenMessageIds).
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      const idA = Array.from(seen.keys())[0];
+
+      // Event B three minutes later (inserted after A => later in iteration).
+      clock.tick(3 * 60 * 1000);
+      await eventQueue.enqueue(createMockEvent({ properties: { b: 1 } }));
+      await eventQueue.flush();
+      const idB = Array.from(seen.keys()).find((k) => k !== idA)!;
+
+      // Three more minutes: A is 6 min old (expired), B is 3 min old (fresh).
+      // A fresh enqueue triggers the prune.
+      clock.tick(3 * 60 * 1000);
+      await eventQueue.enqueue(createMockEvent({ properties: { c: 1 } }));
+
+      expect(seen.has(idA), "leading expired id pruned").to.be.false;
+      expect(
+        seen.has(idB),
+        "fresh id retained (insertion-order scan stops here)"
+      ).to.be.true;
+    });
+
+    it("generateMessageId is stable within a UTC minute and varies across minute or payload", async () => {
+      useContentHashes();
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+      const gen = (e: IFormoEvent) =>
+        (eventQueue as unknown as {
+          generateMessageId: (e: IFormoEvent) => Promise<string>;
+        }).generateMessageId(e);
+
+      const base = createMockEvent({
+        original_timestamp: "2026-01-01T00:00:30.000Z",
+        properties: { a: 1 },
+      });
+      const sameMinute = createMockEvent({
+        original_timestamp: "2026-01-01T00:00:59.999Z",
+        properties: { a: 1 },
+      });
+      const nextMinute = createMockEvent({
+        original_timestamp: "2026-01-01T00:01:00.000Z",
+        properties: { a: 1 },
+      });
+      const diffPayload = createMockEvent({
+        original_timestamp: "2026-01-01T00:00:30.000Z",
+        properties: { a: 2 },
+      });
+
+      const [id1, id2, id3, id4] = await Promise.all([
+        gen(base),
+        gen(sameMinute),
+        gen(nextMinute),
+        gen(diffPayload),
+      ]);
+
+      expect(id1, "same payload + same UTC minute => identical id").to.equal(
+        id2
+      );
+      expect(id1, "crossing the minute boundary => different id").to.not.equal(
+        id3
+      );
+      expect(id1, "different payload => different id").to.not.equal(id4);
     });
   });
 });

--- a/test/lib/queue/EventQueue.spec.ts
+++ b/test/lib/queue/EventQueue.spec.ts
@@ -919,6 +919,64 @@ describe("EventQueue", () => {
       expect(unacked.size, "unacked marker cleared").to.equal(0);
     });
 
+    it("clears dedup state for batches skipped due to mid-flush consent revoke", async () => {
+      // Two large events so the flush splits into separate batches.
+      // After the first batch finishes, canSend flips false; sendBatches
+      // breaks before sending batch 2. Without cleanup, batch 2's items
+      // would stay in unackedIds forever (pruneSeenMessageIds protects
+      // them), and a re-opt-in would silently dedup-drop the same events.
+      let allowed = true;
+      let batchesSent = 0;
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.callsFake(() => {
+        batchesSent++;
+        if (batchesSent === 1) allowed = false;
+        return Promise.resolve(makeResponse(200, "OK"));
+      });
+
+      useUniqueCryptoHashes();
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+        canSend: () => allowed,
+      });
+
+      await enqueueLargeEvents(eventQueue);
+      await eventQueue.flush();
+
+      // At least one batch sent, then consent revoked partway through.
+      expect(fetchStub.callCount, "consent broke the loop early").to.be.lessThan(
+        2 + 5 // arbitrary upper bound, just confirming a break occurred
+      );
+
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      const unacked = (eventQueue as unknown as {
+        unackedIds: Set<string>;
+      }).unackedIds;
+
+      // No unacked markers should leak — every spliced item either
+      // succeeded (cleared on success) or was skipped (cleared on the
+      // consent break path).
+      expect(unacked.size, "unacked markers cleared on consent break").to.equal(
+        0
+      );
+      // Only the successfully delivered items should remain in
+      // seenMessageIds; skipped items are not "delivered duplicates."
+      // 8 events enqueued total — at least one batch was skipped, so
+      // some ids must have been cleared from seenMessageIds.
+      expect(
+        seen.size,
+        "skipped batches' ids cleared from seenMessageIds"
+      ).to.be.lessThan(8);
+      expect(seen.size, "delivered batch ids retained").to.be.greaterThan(0);
+    });
+
     it("allows the same event to be re-sent once the dedup TTL elapses", async () => {
       eventQueue = new EventQueue("test-key", {
         apiHost: "https://api.example.com",

--- a/test/lib/queue/EventQueue.spec.ts
+++ b/test/lib/queue/EventQueue.spec.ts
@@ -1000,6 +1000,55 @@ describe("EventQueue", () => {
       );
     });
 
+    it("refreshes the dedup TTL on delivery so a delayed flush doesn't re-open duplicates", async () => {
+      // message_id is a real sha256 of the payload + minute-rounded
+      // original_timestamp, so to recur the same id across a >TTL real-time
+      // gap both events must carry an identical original_timestamp (e.g. a
+      // caller that supplies/replays a fixed timestamp). Pin it here.
+      const fixedTs = "2020-06-15T12:00:00.000Z";
+
+      // Hold the send in flight, advance the clock past the dedup TTL while
+      // the batch is still unacked (protected by unackedIds), then deliver.
+      // On delivery the timestamp must be refreshed to ack time — otherwise
+      // it stays at the original enqueue time and the next enqueue of the
+      // same id would prune it as expired and re-send a duplicate.
+      let resolveFetch: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+      );
+      fetchStub.resolves(makeResponse(200, "OK"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent({ original_timestamp: fixedTs }));
+      const flushP = eventQueue.flush(); // batch now in flight, still unacked
+
+      // Delivery is delayed past the dedup TTL.
+      clock.tick(6 * 60 * 1000);
+      resolveFetch(makeResponse(200, "OK")); // ack happens at T = 6 min
+      await flushP;
+
+      // Same event (same message_id via the pinned timestamp) re-enqueued
+      // right after the late delivery. Because the TTL was refreshed to ack
+      // time, this is still inside the window and must be dedup'd.
+      await eventQueue.enqueue(createMockEvent({ original_timestamp: fixedTs }));
+      await eventQueue.flush();
+
+      expect(
+        fetchStub.callCount,
+        "delayed delivery refreshed TTL; duplicate suppressed"
+      ).to.equal(1);
+    });
+
     it("does not POST an empty array when a concurrent flush already drained the queue", async () => {
       useUniqueCryptoHashes();
 

--- a/test/lib/queue/EventQueue.spec.ts
+++ b/test/lib/queue/EventQueue.spec.ts
@@ -724,4 +724,121 @@ describe("EventQueue", () => {
         .true;
     });
   });
+
+  // Reproduces the "same message_id, varying sent_at" pattern. The hash is
+  // computed from event payload + UTC-minute-rounded timestamp, so two
+  // identical events within the same minute share a message_id. A re-enqueue
+  // of the same event after a successful flush used to slip through because
+  // dedup state was scoped to the in-queue window only.
+  describe("cross-flush dedup (re-send guard)", () => {
+    let fetchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.resolves(makeResponse(200, "OK"));
+    });
+
+    it("rejects a re-enqueue of the same event after a successful flush", async () => {
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(fetchStub.callCount, "first flush sent once").to.equal(1);
+
+      // Same event (same payload → same message_id) emitted again well
+      // inside the dedup TTL — must NOT be queued or sent.
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(
+        fetchStub.callCount,
+        "re-enqueue after flush is dedup'd, no second send"
+      ).to.equal(1);
+    });
+
+    it("rejects a re-enqueue of the same event after a failed flush", async () => {
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.rejects(new TypeError("Failed to fetch"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(fetchStub.callCount, "first flush attempted").to.equal(1);
+
+      // The first event was dropped on attempt (current semantics); the
+      // re-enqueue is still dedup'd by message_id, so no second send.
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(fetchStub.callCount, "re-enqueue still dedup'd").to.equal(1);
+    });
+
+    it("allows the same event to be re-sent once the dedup TTL elapses", async () => {
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(fetchStub.callCount, "first flush sent once").to.equal(1);
+
+      // Advance past the dedup TTL (5 min) so the id is pruned. The same
+      // event is then a legitimately new emission and goes through.
+      clock.tick(6 * 60 * 1000);
+
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+      expect(fetchStub.callCount, "post-TTL re-enqueue sends again").to.equal(
+        2
+      );
+    });
+
+    it("does not POST an empty array when a concurrent flush already drained the queue", async () => {
+      useUniqueCryptoHashes();
+
+      // Hold the first flush in-flight so a second concurrent flush
+      // awaits it, then resumes after the queue is empty.
+      let resolveFirst: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        })
+      );
+      fetchStub.resolves(makeResponse(200, "OK"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+
+      const first = eventQueue.flush();
+      const second = eventQueue.flush();
+
+      resolveFirst(makeResponse(200, "OK"));
+      await Promise.all([first, second]);
+
+      // Only one real POST — no empty `[]` body from the second flush
+      // resuming after the queue was drained.
+      expect(fetchStub.callCount).to.equal(1);
+    });
+  });
 });

--- a/test/lib/queue/EventQueue.spec.ts
+++ b/test/lib/queue/EventQueue.spec.ts
@@ -1153,18 +1153,26 @@ describe("EventQueue", () => {
       const unacked = (eventQueue as unknown as {
         unackedIds: Set<string>;
       }).unackedIds;
-      // In-flight id is kept in seenMessageIds (so it stays deduped) but the
-      // unacked marker is released so it can't be pinned forever if the
-      // request never settles.
+      // In-flight ids are left FULLY intact by clear(): kept in seenMessageIds
+      // (so a re-send/re-enqueue is rejected) AND still in unackedIds (so the
+      // entry survives TTL/cap eviction until the request settles, and no
+      // competing re-enqueue can form a second generation of the id). The
+      // outstanding handler is the sole owner and releases it on settle.
       expect(seen.size, "in-flight id retained for dedup").to.equal(1);
       expect(
         unacked.size,
-        "unacked released on clear() so prune can reclaim it"
-      ).to.equal(0);
+        "in-flight id still protected until its request settles"
+      ).to.equal(1);
 
       // The in-flight request lands successfully — the event is on the server.
+      // The success path drops the unacked marker and re-anchors the dedup
+      // entry's timestamp to ack time.
       resolveFirst(makeResponse(200, "OK"));
       await first;
+      expect(
+        unacked.size,
+        "unacked released once the request settles"
+      ).to.equal(0);
 
       // Re-enqueue the same event within the dedup TTL: it must be rejected,
       // because the delivered event's id is still tracked.
@@ -1176,8 +1184,8 @@ describe("EventQueue", () => {
         "delivered in-flight event not re-sent after clear()"
       ).to.equal(1);
 
-      // After the TTL elapses the preserved id is prunable (not pinned by
-      // unacked), so the same event becomes a legitimately-new emission.
+      // After the TTL elapses (measured from ack time) the entry is prunable,
+      // so the same event becomes a legitimately-new emission.
       clock.tick(6 * 60 * 1000);
       await eventQueue.enqueue(createMockEvent());
       await eventQueue.flush();
@@ -1185,6 +1193,55 @@ describe("EventQueue", () => {
         fetchStub.callCount,
         "post-TTL re-emission allowed (no permanent suppression)"
       ).to.equal(2);
+    });
+
+    it("clear() leaves an in-flight id protected so a later re-enqueue cannot form a second generation", async () => {
+      // Regression guard for the generational race: after clear(), an in-flight
+      // id must stay in BOTH seenMessageIds and unackedIds. If it were demoted
+      // (kept in seen, dropped from unacked) it could be evicted, letting a
+      // re-enqueue of the same message_id create a second generation that the
+      // ORIGINAL request's success/failure handler would later clobber.
+      let resolveFirst: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        })
+      );
+      fetchStub.resolves(makeResponse(200, "OK"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      const first = eventQueue.flush(); // in flight
+      eventQueue.clear();
+
+      // A re-enqueue of the SAME event while the original is still in flight is
+      // rejected — no second generation forms.
+      await eventQueue.enqueue(createMockEvent());
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      expect(
+        (eventQueue as unknown as { queue: unknown[] }).queue.length,
+        "re-enqueue of in-flight id rejected (no second generation)"
+      ).to.equal(0);
+      expect(seen.size, "still a single tracked id").to.equal(1);
+
+      // Now let the ORIGINAL request finish. Its handler operates on the only
+      // generation; no later enqueue was clobbered.
+      resolveFirst(makeResponse(200, "OK"));
+      await first;
+      expect(
+        fetchStub.callCount,
+        "exactly one delivery; no duplicate from a clobbered generation"
+      ).to.equal(1);
     });
 
     it("clear() still forgets purely-queued (never-sent) events so they can be re-emitted", async () => {

--- a/test/lib/queue/EventQueue.spec.ts
+++ b/test/lib/queue/EventQueue.spec.ts
@@ -760,7 +760,7 @@ describe("EventQueue", () => {
       ).to.equal(1);
     });
 
-    it("rejects a re-enqueue of the same event after a failed flush", async () => {
+    it("allows a re-enqueue of the same event after a failed flush", async () => {
       fetchStub.restore();
       fetchStub = sinon.stub(fetchModule, "default");
       fetchStub.rejects(new TypeError("Failed to fetch"));
@@ -776,11 +776,147 @@ describe("EventQueue", () => {
       await eventQueue.flush();
       expect(fetchStub.callCount, "first flush attempted").to.equal(1);
 
-      // The first event was dropped on attempt (current semantics); the
-      // re-enqueue is still dedup'd by message_id, so no second send.
+      // On failure the dedup entry is dropped so the caller can re-enqueue
+      // from the per-item error callback. Otherwise a transient network
+      // error would silently swallow the retry for the full dedup TTL.
       await eventQueue.enqueue(createMockEvent());
       await eventQueue.flush();
-      expect(fetchStub.callCount, "re-enqueue still dedup'd").to.equal(1);
+      expect(
+        fetchStub.callCount,
+        "re-enqueue after failure is allowed"
+      ).to.equal(2);
+    });
+
+    it("dedup still applies to an in-flight duplicate even if the eventual send fails", async () => {
+      let resolveFirst: (r: Response) => void = () => {};
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.onFirstCall().returns(
+        new Promise<Response>((_resolve, reject) => {
+          resolveFirst = (() => reject(new TypeError("Failed to fetch"))) as never;
+        })
+      );
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      const first = eventQueue.flush();
+
+      // While the first send is in flight, a duplicate enqueue must still
+      // be rejected — otherwise the same event could appear twice in a
+      // later flush even when the first one ultimately fails.
+      await eventQueue.enqueue(createMockEvent());
+
+      resolveFirst(makeResponse(200, "OK"));
+      await first;
+
+      // The in-flight duplicate was dedup'd, so only the original was sent.
+      expect(fetchStub.callCount).to.equal(1);
+    });
+
+    it("protects in-queue / in-flight ids from cap eviction in seenMessageIds", async () => {
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      // Enqueue one event; its id is now in both seenMessageIds and unackedIds.
+      await eventQueue.enqueue(createMockEvent());
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      const unacked = (eventQueue as unknown as {
+        unackedIds: Set<string>;
+      }).unackedIds;
+      expect(unacked.size, "queued id marked unacked").to.equal(1);
+      const queuedId = Array.from(unacked)[0];
+
+      // Flood seenMessageIds past MAX_DEDUP_ENTRIES (1000) with synthetic
+      // ids inserted BEFORE the queued id's insertion position is touched
+      // by eviction — they're inserted after, so the queued id is the
+      // oldest entry and would be the first evicted without protection.
+      // To make the queued id appear first in insertion order, re-set it.
+      const queuedTs = seen.get(queuedId)!;
+      seen.delete(queuedId);
+      seen.set(queuedId, queuedTs);
+      for (let i = 0; i < 1100; i++) {
+        seen.set(`synth-${i}`, Date.now());
+      }
+      expect(seen.size).to.be.greaterThan(1000);
+      expect(seen.has(queuedId), "queued id is the oldest entry").to.be.true;
+
+      // Trigger pruneSeenMessageIds via a fresh enqueue.
+      useUniqueCryptoHashes();
+      await eventQueue.enqueue(
+        createMockEvent({ properties: { unique: "trigger-prune" } })
+      );
+
+      // Cap eviction ran (size dropped close to the cap) and the queued
+      // id survives because it's protected by unackedIds. Size is `cap +
+      // 1` because the triggering enqueue adds its own id after the prune.
+      expect(seen.size, "size capped (≈ MAX_DEDUP_ENTRIES)").to.be.at.most(
+        1001
+      );
+      expect(seen.size, "actually pruned").to.be.lessThan(1101);
+      expect(
+        seen.has(queuedId),
+        "queued id NOT evicted (protected by unackedIds)"
+      ).to.be.true;
+    });
+
+    it("removes the unacked marker on send success but keeps it in seenMessageIds", async () => {
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      const unacked = (eventQueue as unknown as {
+        unackedIds: Set<string>;
+      }).unackedIds;
+      expect(seen.size, "id retained for cross-flush dedup").to.equal(1);
+      expect(unacked.size, "unacked marker cleared after success").to.equal(0);
+    });
+
+    it("removes both unacked and seenMessageIds entries on send failure", async () => {
+      fetchStub.restore();
+      fetchStub = sinon.stub(fetchModule, "default");
+      fetchStub.rejects(new TypeError("Failed to fetch"));
+
+      eventQueue = new EventQueue("test-key", {
+        apiHost: "https://api.example.com",
+        flushAt: 20,
+        flushInterval: 30000,
+        retryCount: 1,
+      });
+
+      await eventQueue.enqueue(createMockEvent());
+      await eventQueue.flush();
+
+      const seen = (eventQueue as unknown as {
+        seenMessageIds: Map<string, number>;
+      }).seenMessageIds;
+      const unacked = (eventQueue as unknown as {
+        unackedIds: Set<string>;
+      }).unackedIds;
+      expect(seen.size, "id cleared on failure so caller can retry").to.equal(
+        0
+      );
+      expect(unacked.size, "unacked marker cleared").to.equal(0);
     });
 
     it("allows the same event to be re-sent once the dedup TTL elapses", async () => {


### PR DESCRIPTION
## Summary
This PR fixes a bug where identical events could be sent multiple times with the same `message_id` but different `sent_at` timestamps. The issue occurred when an event was re-enqueued after a successful flush, as the deduplication state was only scoped to the in-queue window.

## Key Changes
- **Extended dedup scope across flushes**: Changed `payloadHashes` (a `Set`) to `seenMessageIds` (a `Map<string, number>`) that persists across flush operations, tracking when each message ID was first seen
- **Implemented TTL-based pruning**: Added `pruneSeenMessageIds()` method that:
  - Removes expired entries older than `DEDUP_TTL_MS` (5 minutes)
  - Caps the map size at `MAX_DEDUP_ENTRIES` (1,000) to prevent unbounded memory growth from misbehaving callers
  - Uses insertion-order eviction (oldest first) when the cap is exceeded
- **Fixed concurrent flush race condition**: Added a check to prevent POSTing an empty array when a concurrent flush has already drained the queue
- **Updated flush logic**: Removed the deletion of hashes for flushed items, allowing re-enqueued events within the TTL to be properly rejected

## Notable Implementation Details
- The dedup TTL (5 minutes) is wider than the message ID rounding granularity (UTC minute) plus reasonable clock slop to ensure reliable rejection
- The `seenMessageIds` map is cleared only on explicit `reset()` calls, not on flush, to maintain cross-flush dedup guarantees
- Pruning is performed lazily on each `enqueue()` call rather than continuously, balancing memory efficiency with performance
- The implementation uses `forEach` loops for ES5 compatibility without requiring `downlevelIteration`

https://claude.ai/code/session_01FUimEhZU3wrDA4wvDDcPnS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782824340&installation_id=130740768&pr_number=274&repository=getformo%2Fsdk&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fsdk%2Fpull%2F274&signature=40d3a9c6b03e9e92647aa774d51ac9991d3936f8a02ed881d80d8757bd48f7d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->