### PR TITLE
Add timezone-based tracking opt-out via excludeTimezones

### DIFF
--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -2632,9 +2632,14 @@ export class FormoAnalytics implements IFormoAnalytics {
    */
   private persistActiveWallet(): void {
     try {
-      // Never write an identity cookie for an opted-out user; ensure any
-      // prior snapshot is removed instead.
-      if (this.hasOptedOutTracking()) {
+      // Never write an identity cookie for a suppressed visitor (opt-out or
+      // excluded timezone); ensure any prior snapshot is removed instead.
+      // Guards the autocapture / syncWalletState paths, which update
+      // in-memory chain state directly without going through the gated public
+      // connect()/identify()/detect() entry points. In-memory
+      // currentAddress/currentChainId are intentionally left intact for
+      // disconnect correctness; only the persisted cookie is suppressed.
+      if (this.isTrackingSuppressed()) {
         cookie().remove(ACTIVE_WALLET_KEY);
         return;
       }
@@ -2664,9 +2669,10 @@ export class FormoAnalytics implements IFormoAnalytics {
    */
   private loadActiveWallet(): void {
     try {
-      // Never restore wallet identity into memory for an opted-out user
-      // (mirrors persistActiveWallet's guard); drop any stale snapshot.
-      if (this.hasOptedOutTracking()) {
+      // Never restore wallet identity into memory for a suppressed visitor
+      // (opt-out or excluded timezone); mirrors persistActiveWallet's guard.
+      // Drop any stale snapshot.
+      if (this.isTrackingSuppressed()) {
         cookie().remove(ACTIVE_WALLET_KEY);
         return;
       }

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -436,11 +436,10 @@ export class FormoAnalytics implements IFormoAnalytics {
 
     // connect() persists wallet/chain state (active-wallet cookie,
     // currentAddress/currentChainId) before trackEvent's consent check —
-    // gate the whole method so a suppressed visitor (opt-out or excluded
-    // timezone) leaves no session state. The autocapture provider-event path
-    // intentionally still persists state to keep disconnect payloads valid.
+    // gate the whole method so a suppressed visitor or excluded environment
+    // (opt-out / timezone / host / path) leaves no session state.
     if (this.isTrackingSuppressed()) {
-      logger.info("connect() skipped: tracking is suppressed for this visitor");
+      logger.info("connect() skipped: tracking is suppressed for this visitor or environment");
       return;
     }
 
@@ -715,11 +714,11 @@ export class FormoAnalytics implements IFormoAnalytics {
   ): Promise<void> {
     try {
       // identify() writes the user-id cookie and marks wallet
-      // identification before trackEvent's consent check — gate the
-      // whole method so a suppressed visitor (opt-out or excluded timezone)
-      // gets no identity persistence.
+      // identification before trackEvent's consent check — gate the whole
+      // method so a suppressed visitor or excluded environment (opt-out /
+      // timezone / host / path) gets no identity persistence.
       if (this.isTrackingSuppressed()) {
-        logger.info("identify() skipped: tracking is suppressed for this visitor");
+        logger.info("identify() skipped: tracking is suppressed for this visitor or environment");
         return;
       }
       if (!params) {
@@ -883,10 +882,10 @@ export class FormoAnalytics implements IFormoAnalytics {
     callback?: (...args: unknown[]) => void
   ): Promise<void> {
     // detect() marks wallet detection (a cookie write) before
-    // trackEvent's consent check — gate it for suppressed visitors
-    // (opt-out or excluded timezone).
+    // trackEvent's consent check — gate it for a suppressed visitor or
+    // excluded environment (opt-out / timezone / host / path).
     if (this.isTrackingSuppressed()) {
-      logger.info("detect() skipped: tracking is suppressed for this visitor");
+      logger.info("detect() skipped: tracking is suppressed for this visitor or environment");
       return;
     }
     if (this.session.isWalletDetected(rdns))
@@ -1300,9 +1299,15 @@ export class FormoAnalytics implements IFormoAnalytics {
     const nextChainId = await this.getCurrentChainId(provider);
     const wasDisconnected = !this._evmAddress;
 
-    // CRITICAL: Always update state regardless of whether connect tracking is enabled
-    // This ensures disconnect events will have valid address/chainId values
-    this.setChainState('evm', { address, chainId: nextChainId });
+    // Update state regardless of whether connect *event* tracking is enabled,
+    // so disconnect events keep valid address/chainId values. The one
+    // exception is a suppressed visitor / excluded environment (opt-out /
+    // timezone / host / path): don't learn state there, so it can't be
+    // backfilled into a later allowed-page event. (excludeChains is NOT
+    // suppression — it still updates state so currentChainId can gate events.)
+    if (!this.isTrackingSuppressed()) {
+      this.setChainState('evm', { address, chainId: nextChainId });
+    }
 
     // Conditionally emit connect event based on tracking configuration
     const providerInfo = this.getProviderInfo(provider);
@@ -1876,6 +1881,81 @@ export class FormoAnalytics implements IFormoAnalytics {
    * @returns {boolean} True if all tracking and persistence must be suppressed
    */
   private isTrackingSuppressed(): boolean {
+    return this.hasOptedOutTracking() || this.isCurrentEnvironmentExcluded();
+  }
+
+  /**
+   * Whether the current environment is excluded from tracking — the visitor's
+   * timezone, the current hostname, or the current pathname matches a
+   * configured exclusion.
+   *
+   * Timezone is visitor/session-level (stable for the session); host/path are
+   * current-page-level and transient — if a SPA navigates to an allowed path,
+   * tracking resumes for future actions. Used as the "do not write identity or
+   * send events" gate at every entry point that would persist state before the
+   * `shouldTrack()` event gate.
+   * @returns {boolean} True if the current environment is excluded
+   */
+  private isCurrentEnvironmentExcluded(): boolean {
+    return (
+      this.isTimezoneExcluded() ||
+      this.isHostExcluded() ||
+      this.isPathExcluded()
+    );
+  }
+
+  /**
+   * Whether the current hostname matches a configured `tracking.excludeHosts`
+   * entry (exact match). Current-page-level — see isCurrentEnvironmentExcluded.
+   * @returns {boolean} True if the current hostname is excluded
+   */
+  private isHostExcluded(): boolean {
+    const tracking = this.options.tracking;
+    if (
+      tracking === null ||
+      typeof tracking !== "object" ||
+      Array.isArray(tracking)
+    ) {
+      return false;
+    }
+    if (typeof window === "undefined") {
+      return false;
+    }
+    const { excludeHosts = [] } = tracking as TrackingOptions;
+    return excludeHosts.includes(window.location.hostname);
+  }
+
+  /**
+   * Whether the current pathname matches a configured `tracking.excludePaths`
+   * entry (exact match). Current-page-level — see isCurrentEnvironmentExcluded.
+   * @returns {boolean} True if the current pathname is excluded
+   */
+  private isPathExcluded(): boolean {
+    const tracking = this.options.tracking;
+    if (
+      tracking === null ||
+      typeof tracking !== "object" ||
+      Array.isArray(tracking)
+    ) {
+      return false;
+    }
+    if (typeof window === "undefined") {
+      return false;
+    }
+    const { excludePaths = [] } = tracking as TrackingOptions;
+    return excludePaths.includes(window.location.pathname);
+  }
+
+  /**
+   * Whether the current call is in a visitor-level suppression state — opt-out
+   * or excluded timezone — for which any persisted identity cookie should be
+   * actively purged (not merely skipped). Host/path exclusions are
+   * deliberately excluded here: they are transient current-page states, so a
+   * cookie legitimately written on an allowed page must survive a visit to an
+   * excluded route.
+   * @returns {boolean} True if persisted identity must be purged
+   */
+  private isPersistedIdentityPurgeRequired(): boolean {
     return this.hasOptedOutTracking() || this.isTimezoneExcluded();
   }
 
@@ -1929,32 +2009,12 @@ export class FormoAnalytics implements IFormoAnalytics {
       typeof this.options.tracking === "object" &&
       !Array.isArray(this.options.tracking)
     ) {
-      const {
-        excludeHosts = [],
-        excludePaths = [],
-        excludeChains = [],
-      } = this.options.tracking as TrackingOptions;
+      const { excludeChains = [] } = this.options.tracking as TrackingOptions;
 
-      // Check timezone exclusions - opt out visitors in matching timezones
-      // entirely (no identify/connect/track events). Client-side, best-effort.
-      if (this.isTimezoneExcluded()) {
+      // Environment exclusions (timezone / host / path) — no identify / connect
+      // / track events while excluded. Host/path are exact-match.
+      if (this.isCurrentEnvironmentExcluded()) {
         return false;
-      }
-
-      // Check hostname exclusions - use exact matching
-      if (excludeHosts.length > 0 && typeof window !== "undefined") {
-        const hostname = window.location.hostname;
-        if (excludeHosts.includes(hostname)) {
-          return false;
-        }
-      }
-
-      // Check path exclusions - use exact matching
-      if (excludePaths.length > 0 && typeof window !== "undefined") {
-        const pathname = window.location.pathname;
-        if (excludePaths.includes(pathname)) {
-          return false;
-        }
       }
 
       // Check chainId exclusions
@@ -2568,6 +2628,15 @@ export class FormoAnalytics implements IFormoAnalytics {
     chainId?: ChainID;
     address?: Address;
   }): void {
+    // Don't learn or persist wallet state for a suppressed visitor or an
+    // excluded environment (opt-out / timezone / host / path). This prevents
+    // state observed only while excluded from being backfilled into a later
+    // allowed-page event. State legitimately learned on an allowed page is
+    // left untouched (we return without clearing).
+    if (this.isTrackingSuppressed()) {
+      return;
+    }
+
     const { chainId, address } = params;
 
     if (!address) {
@@ -2632,15 +2701,16 @@ export class FormoAnalytics implements IFormoAnalytics {
    */
   private persistActiveWallet(): void {
     try {
-      // Never write an identity cookie for a suppressed visitor (opt-out or
-      // excluded timezone); ensure any prior snapshot is removed instead.
-      // Guards the autocapture / syncWalletState paths, which update
-      // in-memory chain state directly without going through the gated public
-      // connect()/identify()/detect() entry points. In-memory
-      // currentAddress/currentChainId are intentionally left intact for
-      // disconnect correctness; only the persisted cookie is suppressed.
-      if (this.isTrackingSuppressed()) {
+      // Visitor-level suppression (opt-out or excluded timezone): purge any
+      // prior snapshot — these are stable for the session, so deletion is safe.
+      if (this.isPersistedIdentityPurgeRequired()) {
         cookie().remove(ACTIVE_WALLET_KEY);
+        return;
+      }
+      // Current-page exclusion (host/path): do not write a snapshot while on an
+      // excluded route, but leave any existing cookie intact. A cookie written
+      // on an allowed page must survive a transient visit to an excluded one.
+      if (this.isHostExcluded() || this.isPathExcluded()) {
         return;
       }
       if (this.currentAddress) {
@@ -2669,11 +2739,16 @@ export class FormoAnalytics implements IFormoAnalytics {
    */
   private loadActiveWallet(): void {
     try {
-      // Never restore wallet identity into memory for a suppressed visitor
-      // (opt-out or excluded timezone); mirrors persistActiveWallet's guard.
-      // Drop any stale snapshot.
-      if (this.isTrackingSuppressed()) {
+      // Visitor-level suppression (opt-out or excluded timezone): never restore
+      // identity into memory; drop the stale snapshot.
+      if (this.isPersistedIdentityPurgeRequired()) {
         cookie().remove(ACTIVE_WALLET_KEY);
+        return;
+      }
+      // Current-page exclusion (host/path): don't restore into memory while on
+      // an excluded route, but keep the cookie so a later allowed-page load can
+      // restore it.
+      if (this.isHostExcluded() || this.isPathExcluded()) {
         return;
       }
       const raw = cookie().get(ACTIVE_WALLET_KEY) as string | undefined;

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -1300,12 +1300,20 @@ export class FormoAnalytics implements IFormoAnalytics {
     const wasDisconnected = !this._evmAddress;
 
     // Update state regardless of whether connect *event* tracking is enabled,
-    // so disconnect events keep valid address/chainId values. The one
-    // exception is a suppressed visitor / excluded environment (opt-out /
-    // timezone / host / path): don't learn state there, so it can't be
-    // backfilled into a later allowed-page event. (excludeChains is NOT
-    // suppression — it still updates state so currentChainId can gate events.)
-    if (!this.isTrackingSuppressed()) {
+    // so disconnect events keep valid address/chainId values. (excludeChains is
+    // NOT suppression — it still updates state so currentChainId can gate
+    // events.)
+    if (this.isTrackingSuppressed()) {
+      // Suppressed visitor / excluded environment: never LEARN this wallet, so
+      // it can't be backfilled into a later allowed-page event. But if it is a
+      // switch away from a wallet already learned for EVM, drop the stale one
+      // (clearing the active-wallet cookie) rather than leaving it behind.
+      const evmAddress = this._chainState.evm.address;
+      const incoming = validateAndChecksumAddress(address);
+      if (evmAddress && incoming && incoming !== evmAddress) {
+        this.clearChainState('evm');
+      }
+    } else {
       this.setChainState('evm', { address, chainId: nextChainId });
     }
 
@@ -2628,16 +2636,41 @@ export class FormoAnalytics implements IFormoAnalytics {
     chainId?: ChainID;
     address?: Address;
   }): void {
-    // Don't learn or persist wallet state for a suppressed visitor or an
-    // excluded environment (opt-out / timezone / host / path). This prevents
-    // state observed only while excluded from being backfilled into a later
-    // allowed-page event. State legitimately learned on an allowed page is
-    // left untouched (we return without clearing).
+    const { chainId, address } = params;
+
     if (this.isTrackingSuppressed()) {
+      // While suppressed (opt-out / timezone / excluded host or path) we must
+      // never LEARN a new wallet — but we must still CLEAR stale identity.
+      // Otherwise a disconnect or wallet switch observed on a suppressed route
+      // would leave the previously-learned address in memory and in the
+      // active-wallet cookie, attaching it to later allowed-page events.
+      if (!address) {
+        // Disconnect: drop the affected namespace(s).
+        if (chainId !== undefined && chainId !== null) {
+          this.clearChainState(chainId);
+        } else {
+          this.clearChainState("evm");
+          this.clearChainState("solana");
+        }
+        return;
+      }
+      // Address present: a switch away from the wallet already learned in this
+      // namespace invalidates it. Drop the stale one without learning the new
+      // address; a fresh connect (nothing learned yet) or a re-confirmation of
+      // the same address is a no-op.
+      if (chainId === null || chainId === undefined) return;
+      const namespace = this.getNamespace(chainId);
+      const namespaceAddress = this._chainState[namespace].address;
+      const validIncoming = validateAddress(address, chainId);
+      if (
+        namespaceAddress &&
+        validIncoming &&
+        validIncoming !== namespaceAddress
+      ) {
+        this.clearChainState(chainId);
+      }
       return;
     }
-
-    const { chainId, address } = params;
 
     if (!address) {
       if (chainId !== undefined && chainId !== null) {
@@ -2707,13 +2740,14 @@ export class FormoAnalytics implements IFormoAnalytics {
         cookie().remove(ACTIVE_WALLET_KEY);
         return;
       }
-      // Current-page exclusion (host/path): do not write a snapshot while on an
-      // excluded route, but leave any existing cookie intact. A cookie written
-      // on an allowed page must survive a transient visit to an excluded one.
-      if (this.isHostExcluded() || this.isPathExcluded()) {
-        return;
-      }
       if (this.currentAddress) {
+        // Current-page exclusion (host/path): do not write a new snapshot while
+        // on an excluded route, but leave any existing cookie intact. A cookie
+        // written on an allowed page must survive a transient visit to an
+        // excluded one (passive navigation does not call this method).
+        if (this.isHostExcluded() || this.isPathExcluded()) {
+          return;
+        }
         const value = JSON.stringify({
           address: this.currentAddress,
           ...(this.currentChainId !== undefined && { chainId: this.currentChainId }),
@@ -2726,6 +2760,9 @@ export class FormoAnalytics implements IFormoAnalytics {
           ...(domain ? { domain } : {}),
         });
       } else {
+        // No active wallet → clear the snapshot. This runs even on an excluded
+        // route, so a disconnect/switch observed while suppressed actively
+        // removes stale identity instead of leaving it for later allowed events.
         cookie().remove(ACTIVE_WALLET_KEY);
       }
     } catch (err) {

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -1899,9 +1899,12 @@ export class FormoAnalytics implements IFormoAnalytics {
       return false;
     }
     const timezone = getTimezone();
-    return (
-      !!timezone &&
-      excludeTimezones.some((tz) => tz.toLowerCase() === timezone.toLowerCase())
+    if (!timezone) {
+      return false;
+    }
+    const lowerTimezone = timezone.toLowerCase();
+    return excludeTimezones.some(
+      (tz) => typeof tz === "string" && tz.toLowerCase() === lowerTimezone
     );
   }
 

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -53,6 +53,7 @@ import {
   WRAPPED_REQUEST_REF_SYMBOL,
 } from "./types";
 import { validateAddress, validateAndChecksumAddress } from "./utils/address";
+import { getTimezone } from "./utils/timezone";
 import { isLocalhost } from "./validators";
 import { parseChainId } from "./utils/chain";
 import { WagmiEventHandler } from "./wagmi";
@@ -1877,7 +1878,22 @@ export class FormoAnalytics implements IFormoAnalytics {
         excludeHosts = [],
         excludePaths = [],
         excludeChains = [],
+        excludeTimezones = [],
       } = this.options.tracking as TrackingOptions;
+
+      // Check timezone exclusions - opt out visitors in matching timezones
+      // entirely (no identify/connect/track events). Client-side, best-effort.
+      if (excludeTimezones.length > 0) {
+        const timezone = getTimezone();
+        if (
+          timezone &&
+          excludeTimezones.some(
+            (tz) => tz.toLowerCase() === timezone.toLowerCase()
+          )
+        ) {
+          return false;
+        }
+      }
 
       // Check hostname exclusions - use exact matching
       if (excludeHosts.length > 0 && typeof window !== "undefined") {

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -1304,15 +1304,7 @@ export class FormoAnalytics implements IFormoAnalytics {
     // NOT suppression — it still updates state so currentChainId can gate
     // events.)
     if (this.isTrackingSuppressed()) {
-      // Suppressed visitor / excluded environment: never LEARN this wallet, so
-      // it can't be backfilled into a later allowed-page event. But if it is a
-      // switch away from a wallet already learned for EVM, drop the stale one
-      // (clearing the active-wallet cookie) rather than leaving it behind.
-      const evmAddress = this._chainState.evm.address;
-      const incoming = validateAndChecksumAddress(address);
-      if (evmAddress && incoming && incoming !== evmAddress) {
-        this.clearChainState('evm');
-      }
+      this.clearStaleEvmWalletOnSwitchWhileSuppressed(address);
     } else {
       this.setChainState('evm', { address, chainId: nextChainId });
     }
@@ -1493,13 +1485,18 @@ export class FormoAnalytics implements IFormoAnalytics {
         // Check if this provider is the currently active one
         const isActiveProvider = this._provider === provider;
 
-        // CRITICAL: Always update state from active provider regardless of tracking config
-        // This ensures disconnect events will have valid address/chainId values
+        // Update state from active provider so disconnect events keep valid
+        // address/chainId values — except while suppressed, where we must not
+        // LEARN identity (only drop a stale EVM wallet on a switch).
         if (isActiveProvider) {
-          this.setChainState('evm', {
-            chainId,
-            address: validateAndChecksumAddress(address) || undefined,
-          });
+          if (this.isTrackingSuppressed()) {
+            this.clearStaleEvmWalletOnSwitchWhileSuppressed(address);
+          } else {
+            this.setChainState('evm', {
+              chainId,
+              address: validateAndChecksumAddress(address) || undefined,
+            });
+          }
         }
 
         // Conditionally emit connect event based on tracking configuration
@@ -2411,8 +2408,29 @@ export class FormoAnalytics implements IFormoAnalytics {
    * value in the normal way; existing connections are never clobbered.
    */
   private backfillActiveWallet(address: Address, chainId?: ChainID): void {
+    // Never learn identity while suppressed (opt-out / timezone / excluded host
+    // or path). A signature/transaction observed on an excluded route must not
+    // populate currentAddress for later allowed-page events. backfill only ever
+    // *adds* an address (it no-ops when one is already known), so there is no
+    // stale state to clear here.
+    if (this.isTrackingSuppressed()) return;
     if (this._evmAddress) return;
     this.setChainState('evm', { address, chainId });
+  }
+
+  /**
+   * Apply an EVM autocapture connect/switch while tracking is suppressed
+   * (opt-out / timezone / excluded host or path): never LEARN the wallet, but
+   * if it is a switch away from an already-learned EVM wallet, drop the stale
+   * one (which also clears the active-wallet cookie) so it can't attach to a
+   * later allowed-page event.
+   */
+  private clearStaleEvmWalletOnSwitchWhileSuppressed(address: string): void {
+    const evmAddress = this._chainState.evm.address;
+    const incoming = validateAndChecksumAddress(address);
+    if (evmAddress && incoming && incoming !== evmAddress) {
+      this.clearChainState('evm');
+    }
   }
 
   /**

--- a/src/FormoAnalytics.ts
+++ b/src/FormoAnalytics.ts
@@ -434,6 +434,16 @@ export class FormoAnalytics implements IFormoAnalytics {
       return;
     }
 
+    // connect() persists wallet/chain state (active-wallet cookie,
+    // currentAddress/currentChainId) before trackEvent's consent check —
+    // gate the whole method so a suppressed visitor (opt-out or excluded
+    // timezone) leaves no session state. The autocapture provider-event path
+    // intentionally still persists state to keep disconnect payloads valid.
+    if (this.isTrackingSuppressed()) {
+      logger.info("connect() skipped: tracking is suppressed for this visitor");
+      return;
+    }
+
     this.setChainState(chainId, { address: validAddress });
 
     await this.trackEvent(
@@ -706,9 +716,10 @@ export class FormoAnalytics implements IFormoAnalytics {
     try {
       // identify() writes the user-id cookie and marks wallet
       // identification before trackEvent's consent check — gate the
-      // whole method so an opted-out user gets no identity persistence.
-      if (this.hasOptedOutTracking()) {
-        logger.info("identify() skipped: user has opted out of tracking");
+      // whole method so a suppressed visitor (opt-out or excluded timezone)
+      // gets no identity persistence.
+      if (this.isTrackingSuppressed()) {
+        logger.info("identify() skipped: tracking is suppressed for this visitor");
         return;
       }
       if (!params) {
@@ -872,9 +883,10 @@ export class FormoAnalytics implements IFormoAnalytics {
     callback?: (...args: unknown[]) => void
   ): Promise<void> {
     // detect() marks wallet detection (a cookie write) before
-    // trackEvent's consent check — gate it on opt-out.
-    if (this.hasOptedOutTracking()) {
-      logger.info("detect() skipped: user has opted out of tracking");
+    // trackEvent's consent check — gate it for suppressed visitors
+    // (opt-out or excluded timezone).
+    if (this.isTrackingSuppressed()) {
+      logger.info("detect() skipped: tracking is suppressed for this visitor");
       return;
     }
     if (this.session.isWalletDetected(rdns))
@@ -1854,6 +1866,46 @@ export class FormoAnalytics implements IFormoAnalytics {
   }
 
   /**
+   * Visitor-level tracking suppression.
+   *
+   * Returns true when the SDK must not persist any identity/session/chain
+   * state or send any events for this visitor — i.e. an explicit opt-out or a
+   * jurisdiction/timezone exclusion. Public entry points that write state
+   * before reaching the `shouldTrack()` event gate (identify/connect/detect)
+   * check this first so suppressed visitors leave no cookies or session state.
+   * @returns {boolean} True if all tracking and persistence must be suppressed
+   */
+  private isTrackingSuppressed(): boolean {
+    return this.hasOptedOutTracking() || this.isTimezoneExcluded();
+  }
+
+  /**
+   * Whether the visitor's browser-resolved timezone matches a configured
+   * `tracking.excludeTimezones` entry (case-insensitive). Client-side and
+   * best-effort — see TrackingOptions.excludeTimezones.
+   * @returns {boolean} True if the current timezone is excluded
+   */
+  private isTimezoneExcluded(): boolean {
+    const tracking = this.options.tracking;
+    if (
+      tracking === null ||
+      typeof tracking !== "object" ||
+      Array.isArray(tracking)
+    ) {
+      return false;
+    }
+    const { excludeTimezones = [] } = tracking as TrackingOptions;
+    if (excludeTimezones.length === 0) {
+      return false;
+    }
+    const timezone = getTimezone();
+    return (
+      !!timezone &&
+      excludeTimezones.some((tz) => tz.toLowerCase() === timezone.toLowerCase())
+    );
+  }
+
+  /**
    * Determines if tracking should be enabled based on configuration and consent
    * @returns {boolean} True if tracking should be enabled
    */
@@ -1878,21 +1930,12 @@ export class FormoAnalytics implements IFormoAnalytics {
         excludeHosts = [],
         excludePaths = [],
         excludeChains = [],
-        excludeTimezones = [],
       } = this.options.tracking as TrackingOptions;
 
       // Check timezone exclusions - opt out visitors in matching timezones
       // entirely (no identify/connect/track events). Client-side, best-effort.
-      if (excludeTimezones.length > 0) {
-        const timezone = getTimezone();
-        if (
-          timezone &&
-          excludeTimezones.some(
-            (tz) => tz.toLowerCase() === timezone.toLowerCase()
-          )
-        ) {
-          return false;
-        }
+      if (this.isTimezoneExcluded()) {
+        return false;
       }
 
       // Check hostname exclusions - use exact matching

--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -18,7 +18,7 @@ import {
   TransactionStatus,
   UTMParameters,
 } from "../types";
-import { toSnakeCase } from "../utils";
+import { toSnakeCase, getTimezone } from "../utils";
 import { validateAddress } from "../utils/address";
 import { getCurrentTimeFormatted } from "../utils/timestamp";
 import { isUndefined } from "../validators";
@@ -84,12 +84,7 @@ class EventFactory implements IEventFactory {
     return validateAddress(address, chainId) || null;
   }
   private getTimezone(): string {
-    try {
-      return Intl.DateTimeFormat().resolvedOptions().timeZone;
-    } catch (error) {
-      logger.error("Error resolving timezone:", error);
-      return "";
-    }
+    return getTimezone();
   }
 
   private getLocation(): string {

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -125,6 +125,20 @@ export interface TrackingOptions {
   excludePaths?: string[];
   excludeChains?: ChainID[];
   /**
+   * IANA timezone names to opt out of tracking entirely. When the visitor's
+   * resolved timezone (via `Intl.DateTimeFormat().resolvedOptions().timeZone`)
+   * matches one of these, no events are enqueued or sent — including `identify`
+   * and `connect`. Matched case-insensitively against the full timezone string.
+   *
+   * Note: this is client-side, timezone-derived geolocation. It is best-effort
+   * and can be bypassed (a VPN does not change the browser timezone, and users
+   * can change their OS timezone). For authoritative jurisdiction blocking, use
+   * server-side IP geolocation at your ingest endpoint instead.
+   *
+   * @example ["Europe/London", "America/New_York"]
+   */
+  excludeTimezones?: string[];
+  /**
    * Additional query parameter names to strip from forwarded and stored URLs,
    * on top of a built-in always-on denylist (currently `privy_oauth_code`,
    * `privy_oauth_state`, and `privy_oauth_provider`) that cannot be disabled.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./base";
 export * from "./converter";
 export * from "./generate";
 export * from "./hash";
+export * from "./timezone";

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,16 @@
+import { logger } from "../logger";
+
+/**
+ * Resolve the current IANA timezone (e.g. "Europe/London") via the Intl API.
+ * Returns "" when the timezone cannot be resolved (e.g. Intl unavailable).
+ */
+const getTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch (error) {
+    logger.error("Error resolving timezone:", error);
+    return "";
+  }
+};
+
+export { getTimezone };

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -6,7 +6,7 @@ import { logger } from "../logger";
  */
 const getTimezone = (): string => {
   try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
   } catch (error) {
     logger.error("Error resolving timezone:", error);
     return "";

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -312,4 +312,41 @@ describe("Tracking timezone exclusion", () => {
     expect(formo.currentAddress).to.be.oneOf([undefined, null]);
     expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
   });
+
+  it("does not learn identity via backfillActiveWallet while on an excluded path", async () => {
+    // backfillActiveWallet() is the shared sink for the autocapture
+    // signature/transaction paths; a signature/transaction observed on an
+    // excluded route must not populate currentAddress.
+    navigateTo("https://example.com/admin");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+
+    (formo as any).backfillActiveWallet(ADDRESS, 1);
+
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
+
+  it("backfills identity via backfillActiveWallet on an allowed path (control)", async () => {
+    navigateTo("https://example.com/");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+
+    (formo as any).backfillActiveWallet(ADDRESS, 1);
+
+    expect(formo.currentAddress).to.equal(ADDRESS);
+  });
+
+  it("drops a stale EVM wallet on switch via the suppressed autocapture helper", async () => {
+    // Helper shared by the EIP-1193 onAccountsChanged / onConnected listeners.
+    const ADDRESS_B = "0x1095bBe769fDab716A823d0f7149CAD713d20A13";
+    navigateTo("https://example.com/");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(formo.currentAddress).to.equal(ADDRESS);
+
+    navigateTo("https://example.com/admin");
+    (formo as any).clearStaleEvmWalletOnSwitchWhileSuppressed(ADDRESS_B);
+
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
 });

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -3,7 +3,8 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import { JSDOM } from "jsdom";
 import { FormoAnalytics } from "../src/FormoAnalytics";
-import { initStorageManager } from "../src/storage";
+import { initStorageManager, cookie } from "../src/storage";
+import { ACTIVE_WALLET_KEY } from "../src/constants";
 import type { TrackingOptions } from "../src/types";
 
 /**
@@ -164,5 +165,29 @@ describe("Tracking timezone exclusion", () => {
     const session = (formo as any).session;
     expect(session.isWalletIdentified(ADDRESS, "io.metamask")).to.equal(false);
     expect(session.isWalletDetected("io.metamask")).to.equal(false);
+  });
+
+  it("does not persist an active-wallet cookie via the autocapture/sync path", async () => {
+    const ADDRESS = "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e";
+    stubTimezone("Europe/London");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+
+    // syncWalletState() is the entry point used by the EIP-1193 and Wagmi
+    // autocapture handlers; it updates chain state directly, bypassing the
+    // gated public connect(). The persistence guard must still suppress the
+    // active-wallet cookie for a suppressed visitor.
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
+
+  it("persists an active-wallet cookie for a non-excluded visitor (control)", async () => {
+    const ADDRESS = "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e";
+    stubTimezone("America/New_York");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.ok;
   });
 });

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -16,6 +16,7 @@ import type { TrackingOptions } from "../src/types";
 describe("Tracking timezone exclusion", () => {
   let sandbox: sinon.SinonSandbox;
   let jsdom: JSDOM;
+  const originalIntl = global.Intl;
 
   function stubTimezone(timeZone: string) {
     Object.defineProperty(global, "Intl", {
@@ -93,7 +94,7 @@ describe("Tracking timezone exclusion", () => {
     delete (global as any).localStorage;
     delete (global as any).sessionStorage;
     delete (global as any).crypto;
-    delete (global as any).Intl;
+    global.Intl = originalIntl;
     if (jsdom) jsdom.window.close();
   });
 

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -239,4 +239,40 @@ describe("Tracking timezone exclusion", () => {
     navigateTo("https://example.com/dashboard");
     expect((formo as any).shouldTrack()).to.equal(true);
   });
+
+  it("clears stale identity when a disconnect is observed on an excluded path", async () => {
+    // Learn wallet A on an allowed path.
+    navigateTo("https://example.com/");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(formo.currentAddress).to.equal(ADDRESS);
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.ok;
+
+    // Disconnect observed while on the excluded path must clear the stale
+    // wallet (memory + cookie), not leave it for later allowed events.
+    navigateTo("https://example.com/admin");
+    formo.syncWalletState({ chainId: 1 });
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+
+    // Back on an allowed path the stale address must not reappear.
+    navigateTo("https://example.com/dashboard");
+    expect((formo as any).shouldTrack()).to.equal(true);
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+  });
+
+  it("clears stale identity when a wallet switch is observed on an excluded path", async () => {
+    const ADDRESS_B = "0x1095bBe769fDab716A823d0f7149CAD713d20A13";
+    navigateTo("https://example.com/");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(formo.currentAddress).to.equal(ADDRESS);
+
+    // A switch to a different wallet on the excluded path must drop the stale
+    // wallet without learning the new one.
+    navigateTo("https://example.com/admin");
+    formo.syncWalletState({ chainId: 1, address: ADDRESS_B });
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
 });

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -146,4 +146,22 @@ describe("Tracking timezone exclusion", () => {
 
     expect(addEvent.called).to.equal(false);
   });
+
+  it("does not persist wallet/identity state for an excluded visitor", async () => {
+    const ADDRESS = "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e";
+    stubTimezone("Europe/London");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+
+    await formo.identify({ address: ADDRESS, rdns: "io.metamask" });
+    await formo.connect({ chainId: 1, address: ADDRESS });
+    await formo.detect({ providerName: "MetaMask", rdns: "io.metamask" });
+
+    // connect() must not have run setChainState()
+    expect(formo.currentAddress).to.not.equal(ADDRESS);
+    expect(formo.currentChainId).to.be.oneOf([undefined, null]);
+    // identify()/detect() must not have written session markers
+    const session = (formo as any).session;
+    expect(session.isWalletIdentified(ADDRESS, "io.metamask")).to.equal(false);
+    expect(session.isWalletDetected("io.metamask")).to.equal(false);
+  });
 });

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { JSDOM } from "jsdom";
+import { FormoAnalytics } from "../src/FormoAnalytics";
+import { initStorageManager } from "../src/storage";
+import type { TrackingOptions } from "../src/types";
+
+/**
+ * Timezone-based tracking opt-out.
+ *
+ * Verifies that `tracking.excludeTimezones` gates the single `shouldTrack()`
+ * choke point that all events (page/identify/connect/track/...) flow through,
+ * so visitors in an excluded timezone produce no events at all.
+ */
+describe("Tracking timezone exclusion", () => {
+  let sandbox: sinon.SinonSandbox;
+  let jsdom: JSDOM;
+
+  function stubTimezone(timeZone: string) {
+    Object.defineProperty(global, "Intl", {
+      value: {
+        DateTimeFormat: () => ({
+          resolvedOptions: () => ({ timeZone }),
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  async function makeAnalytics(
+    tracking?: boolean | TrackingOptions
+  ): Promise<FormoAnalytics> {
+    // Use wagmi mode to skip browser-dependent provider detection.
+    const mockWagmiConfig = {
+      subscribe: sandbox.stub().returns(() => {}),
+      state: {
+        status: "disconnected",
+        connections: new Map(),
+        current: undefined,
+        chainId: undefined,
+      },
+      _internal: { store: { subscribe: sandbox.stub().returns(() => {}) } },
+    };
+    return FormoAnalytics.init("test-write-key", {
+      tracking,
+      wagmi: { config: mockWagmiConfig as any },
+    });
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    jsdom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>", {
+      url: "https://example.com",
+    });
+    Object.defineProperty(global, "window", {
+      value: jsdom.window, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "document", {
+      value: jsdom.window.document, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "location", {
+      value: jsdom.window.location, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "globalThis", {
+      value: jsdom.window, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "navigator", {
+      value: jsdom.window.navigator, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "localStorage", {
+      value: jsdom.window.localStorage, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "sessionStorage", {
+      value: jsdom.window.sessionStorage, writable: true, configurable: true,
+    });
+    Object.defineProperty(global, "crypto", {
+      value: { randomUUID: () => "mock-uuid-1234" },
+      writable: true, configurable: true,
+    });
+
+    initStorageManager("test-write-key");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).location;
+    delete (global as any).globalThis;
+    delete (global as any).navigator;
+    delete (global as any).localStorage;
+    delete (global as any).sessionStorage;
+    delete (global as any).crypto;
+    delete (global as any).Intl;
+    if (jsdom) jsdom.window.close();
+  });
+
+  it("blocks tracking when the visitor timezone is excluded", async () => {
+    stubTimezone("Europe/London");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+    expect((formo as any).shouldTrack()).to.equal(false);
+  });
+
+  it("allows tracking when the visitor timezone is not excluded", async () => {
+    stubTimezone("America/New_York");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+    expect((formo as any).shouldTrack()).to.equal(true);
+  });
+
+  it("matches the timezone case-insensitively", async () => {
+    stubTimezone("Europe/London");
+    const formo = await makeAnalytics({ excludeTimezones: ["europe/london"] });
+    expect((formo as any).shouldTrack()).to.equal(false);
+  });
+
+  it("allows tracking when no excludeTimezones are configured", async () => {
+    stubTimezone("Europe/London");
+    const formo = await makeAnalytics({});
+    expect((formo as any).shouldTrack()).to.equal(true);
+  });
+
+  it("does not block when the timezone cannot be resolved", async () => {
+    stubTimezone("");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+    expect((formo as any).shouldTrack()).to.equal(true);
+  });
+
+  it("prevents identify and connect events from being enqueued", async () => {
+    stubTimezone("Europe/London");
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+    const addEvent = sandbox.stub(
+      (formo as any).eventManager,
+      "addEvent"
+    ).resolves();
+
+    await formo.identify({
+      address: "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e",
+      userId: "user-1",
+    });
+    await formo.connect({
+      chainId: 1,
+      address: "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e",
+    });
+
+    expect(addEvent.called).to.equal(false);
+  });
+});

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -190,4 +190,53 @@ describe("Tracking timezone exclusion", () => {
 
     expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.ok;
   });
+
+  // --- Host / path (current-page) suppression ---------------------------------
+
+  const ADDRESS = "0x82827Bc8342a16b681AfbA6B979E3D1aE5F28a0e";
+
+  function navigateTo(url: string) {
+    jsdom.reconfigure({ url });
+  }
+
+  it("does not track or persist while on an excluded host", async () => {
+    navigateTo("https://staging.example.com/");
+    const formo = await makeAnalytics({ excludeHosts: ["staging.example.com"] });
+
+    expect((formo as any).shouldTrack()).to.equal(false);
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
+
+  it("does not track or persist while on an excluded path", async () => {
+    navigateTo("https://example.com/admin");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+
+    expect((formo as any).shouldTrack()).to.equal(false);
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
+
+  it("does not delete an existing cookie when navigating onto an excluded path", async () => {
+    // Connect on an allowed path → cookie written.
+    navigateTo("https://example.com/");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.ok;
+
+    // Navigate onto the excluded path → cookie must survive (no new write,
+    // but no destructive delete either).
+    navigateTo("https://example.com/admin");
+    formo.syncWalletState({ chainId: 1, address: ADDRESS });
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.ok;
+  });
+
+  it("resumes tracking after navigating from an excluded path to an allowed one", async () => {
+    navigateTo("https://example.com/admin");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+    expect((formo as any).shouldTrack()).to.equal(false);
+
+    navigateTo("https://example.com/dashboard");
+    expect((formo as any).shouldTrack()).to.equal(true);
+  });
 });

--- a/test/trackingTimezoneExclusion.spec.ts
+++ b/test/trackingTimezoneExclusion.spec.ts
@@ -275,4 +275,41 @@ describe("Tracking timezone exclusion", () => {
     expect(formo.currentAddress).to.be.oneOf([undefined, null]);
     expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
   });
+
+  it("does not write session markers via identify/detect on an excluded path", async () => {
+    navigateTo("https://example.com/admin");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+
+    await formo.identify({ address: ADDRESS, rdns: "io.metamask" });
+    await formo.detect({ providerName: "MetaMask", rdns: "io.metamask" });
+
+    const session = (formo as any).session;
+    expect(session.isWalletIdentified(ADDRESS, "io.metamask")).to.equal(false);
+    expect(session.isWalletDetected("io.metamask")).to.equal(false);
+  });
+
+  it("does not restore the active-wallet snapshot at init on an excluded path, but keeps the cookie", async () => {
+    // Seed a snapshot as if written on a previous allowed-page visit.
+    cookie().set(ACTIVE_WALLET_KEY, JSON.stringify({ address: ADDRESS, chainId: 1 }), {
+      path: "/",
+    });
+    navigateTo("https://example.com/admin");
+    const formo = await makeAnalytics({ excludePaths: ["/admin"] });
+
+    // Not restored into memory while on the excluded route...
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+    // ...but the cookie is preserved for a later allowed-page load.
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.be.ok;
+  });
+
+  it("purges the active-wallet snapshot at init for an excluded-timezone visitor", async () => {
+    stubTimezone("Europe/London");
+    cookie().set(ACTIVE_WALLET_KEY, JSON.stringify({ address: ADDRESS, chainId: 1 }), {
+      path: "/",
+    });
+    const formo = await makeAnalytics({ excludeTimezones: ["Europe/London"] });
+
+    expect(formo.currentAddress).to.be.oneOf([undefined, null]);
+    expect(cookie().get(ACTIVE_WALLET_KEY)).to.not.be.ok;
+  });
 });


### PR DESCRIPTION
## Summary
Adds support for excluding visitors from tracking based on their IANA timezone. When a visitor's resolved timezone matches one of the configured `excludeTimezones`, no events (identify, connect, track, etc.) are enqueued or sent.

## Key Changes
- **New utility function** `getTimezone()` in `src/utils/timezone.ts` that resolves the current IANA timezone via the `Intl.DateTimeFormat` API with error handling
- **Updated `TrackingOptions` interface** to include optional `excludeTimezones: string[]` field with comprehensive documentation noting this is client-side, best-effort geolocation
- **Added timezone check** in `FormoAnalytics.shouldTrack()` that gates all event tracking at the single choke point, ensuring excluded timezones produce no events at all
- **Refactored `EventFactory`** to use the new shared `getTimezone()` utility instead of duplicating the logic
- **Comprehensive test suite** (`test/trackingTimezoneExclusion.spec.ts`) covering:
  - Blocking tracking for excluded timezones
  - Allowing tracking for non-excluded timezones
  - Case-insensitive timezone matching
  - Behavior when no exclusions are configured
  - Graceful handling when timezone cannot be resolved
  - Verification that identify/connect events are prevented from being enqueued

## Implementation Details
- Timezone matching is case-insensitive to handle variations in how timezones are specified
- Returns empty string when timezone resolution fails, which does not trigger exclusion (fail-open approach)
- Documentation explicitly notes this is client-side geolocation that can be bypassed (VPN, OS timezone changes) and recommends server-side IP geolocation for authoritative jurisdiction blocking

https://claude.ai/code/session_01QoaE5LN9ksZ2eeaxZr1MZc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783563761&installation_id=130740768&pr_number=283&repository=getformo%2Fsdk&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fsdk%2Fpull%2F283&signature=69ee56dd18c8c7c1611fa2714342e567fcd074a4b9eb3e33aa2f1741419b1a7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->