### PR TITLE
Add af and referrer to default referral query parameters

### DIFF
--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -30,6 +30,7 @@ import {
   CHANNEL,
   CLICK_ID_PARAMS,
   DEFAULT_EXCLUDED_QUERY_PARAMS,
+  DEFAULT_REFERRAL_PARAMS,
   PAGE_PROPERTIES_EXCLUDED_FIELDS,
   VERSION,
 } from "./constants";
@@ -191,10 +192,9 @@ class EventFactory implements IEventFactory {
     // - If no referral config exists → use defaults
     // - If referral config exists but queryParams is undefined → use defaults
     // - If referral config exists with queryParams → use those
-    const defaultParams = ["ref", "referral", "refcode"];
     const referralParams = !this.options?.referral
-      ? defaultParams  // No referral config at all → use defaults
-      : (this.options.referral.queryParams ?? defaultParams);  // Has config → use queryParams or defaults
+      ? DEFAULT_REFERRAL_PARAMS  // No referral config at all → use defaults
+      : (this.options.referral.queryParams ?? DEFAULT_REFERRAL_PARAMS);  // Has config → use queryParams or defaults
 
     // Check query parameters (if any configured)
     for (const param of referralParams) {

--- a/src/event/constants.ts
+++ b/src/event/constants.ts
@@ -35,6 +35,22 @@ const DEFAULT_EXCLUDED_QUERY_PARAMS = [
 ] as const;
 
 /**
+ * Default query parameter names checked (in order) for a referral code on the
+ * landing-page URL. The first parameter present supplies the `ref` traffic
+ * source. Consumers can override this list via `referral.queryParams`.
+ *
+ * Keep in sync with the ReferralOptions.queryParams @default in
+ * src/types/base.ts.
+ */
+const DEFAULT_REFERRAL_PARAMS = [
+  'ref',
+  'referral',
+  'refcode',
+  'af',
+  'referrer',
+] as const;
+
+/**
  * Fields that should be excluded from page event properties parsing
  * These are either:
  * - Already captured in event context (UTM params, referral params, click IDs)
@@ -47,10 +63,7 @@ const PAGE_PROPERTIES_EXCLUDED_FIELDS = new Set<string>([
   'utm_campaign',
   'utm_term',
   'utm_content',
-  'ref',
-  'referral',
-  'refcode',
-  'referrer',
+  ...DEFAULT_REFERRAL_PARAMS,
   ...CLICK_ID_PARAMS,
   // Semantic event properties (should not be overridden by URL params)
   'category',
@@ -66,5 +79,6 @@ export {
   VERSION,
   CLICK_ID_PARAMS,
   DEFAULT_EXCLUDED_QUERY_PARAMS,
+  DEFAULT_REFERRAL_PARAMS,
   PAGE_PROPERTIES_EXCLUDED_FIELDS,
 };

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -196,8 +196,8 @@ export interface AutocaptureOptions {
 export interface ReferralOptions {
   /**
    * Custom query parameter names to check for referral codes
-   * @default ["ref", "referral", "refcode"]
-   * @example ["via", "referrer", "source"] - will check ?via=CODE, ?referrer=CODE, ?source=CODE
+   * @default ["ref", "referral", "refcode", "af", "referrer"]
+   * @example ["via", "partner", "source"] - will check ?via=CODE, ?partner=CODE, ?source=CODE
    */
   queryParams?: string[];
 

--- a/test/lib/event/PagePropertiesParsing.spec.ts
+++ b/test/lib/event/PagePropertiesParsing.spec.ts
@@ -304,13 +304,14 @@ describe("Page Event Property Parsing", () => {
     });
 
     it("should exclude referral parameters", async () => {
-      setMockLocation("https://formo.so/blog?ref=abc123&referral=partner&refcode=xyz");
+      setMockLocation("https://formo.so/blog?ref=abc123&referral=partner&refcode=xyz&af=aff1");
 
       const props = await getPageProperties();
 
       expect(props.ref).to.be.undefined;
       expect(props.referral).to.be.undefined;
       expect(props.refcode).to.be.undefined;
+      expect(props.af).to.be.undefined;
     });
 
     it("should exclude referrer parameter", async () => {
@@ -802,6 +803,54 @@ describe("Page Event Property Parsing", () => {
       setMockLocation("https://formo.so/", "https://app.formo.so/");
       const context = await getPageContext();
       expect(context.referrer).to.equal("https://app.formo.so/");
+    });
+  });
+
+  describe("Referral code parameter (default query params)", () => {
+    // `ref` is sticky across the session, so clear the stored traffic source
+    // before each test to assert per-URL extraction cleanly.
+    beforeEach(() => {
+      try {
+        session().remove(SESSION_TRAFFIC_SOURCE_KEY);
+      } catch {}
+    });
+
+    const cases: Array<[string, string]> = [
+      ["ref", "abc123"],
+      ["referral", "partner"],
+      ["refcode", "xyz789"],
+      ["af", "aff42"],
+      ["referrer", "ambassador"],
+    ];
+
+    cases.forEach(([param, code]) => {
+      it(`should capture ?${param}=CODE into context.ref`, async () => {
+        setMockLocation(`https://formo.so/?${param}=${code}`);
+
+        const context = await getPageContext();
+
+        expect(context.ref).to.equal(code);
+      });
+    });
+
+    it("should keep the ?referrer referral code separate from document.referrer", async () => {
+      // ?referrer is a referral code (context.ref); document.referrer is the
+      // external entry URL (context.referrer). They must not be conflated.
+      setMockLocation("https://formo.so/?referrer=ambassador", "https://google.com/");
+
+      const context = await getPageContext();
+
+      expect(context.ref).to.equal("ambassador");
+      expect(context.referrer).to.equal("https://google.com/");
+    });
+
+    it("should resolve referral params in default order (earlier param wins)", async () => {
+      setMockLocation("https://formo.so/?af=aff42&referrer=ambassador&ref=abc123");
+
+      const context = await getPageContext();
+
+      // `ref` precedes `af` and `referrer` in the default list.
+      expect(context.ref).to.equal("abc123");
     });
   });
 });


### PR DESCRIPTION
## Summary
Expanded the default referral code query parameters to include `af` (affiliate) and `referrer` parameters, in addition to the existing `ref`, `referral`, and `refcode` parameters. This allows the SDK to capture more common referral attribution sources out of the box.

## Key Changes
- **Added `af` and `referrer` to default referral parameters**: Extended `DEFAULT_REFERRAL_PARAMS` constant to include these additional attribution parameters in the order: `ref`, `referral`, `refcode`, `af`, `referrer`
- **Centralized parameter definitions**: Created `DEFAULT_REFERRAL_PARAMS` constant in `src/event/constants.ts` to serve as the single source of truth for default referral parameters
- **Updated page properties exclusion**: Modified `PAGE_PROPERTIES_EXCLUDED_FIELDS` to use the new `DEFAULT_REFERRAL_PARAMS` constant instead of hardcoding individual parameter names
- **Updated EventFactory**: Replaced hardcoded default parameter list with reference to `DEFAULT_REFERRAL_PARAMS` constant
- **Updated ReferralOptions documentation**: Updated JSDoc to reflect the new default parameters and provided a more realistic example
- **Added comprehensive test coverage**: Added new test suite "Referral code parameter (default query params)" with tests for:
  - Each individual parameter being captured into `context.ref`
  - Proper separation of `?referrer` query parameter from `document.referrer`
  - Parameter precedence (first parameter in the list wins)
  - Updated existing test to verify `af` parameter is excluded from page properties

## Implementation Details
- Parameters are checked in order, with the first present parameter supplying the referral code
- The `referrer` parameter is intentionally included to capture referral codes, while being kept separate from the `document.referrer` property (which represents the external entry URL)
- All referral parameters are excluded from page event properties to prevent them from polluting analytics data
- The constant is kept in sync with the `ReferralOptions.queryParams` JSDoc default value

https://claude.ai/code/session_01NE7oDonRuxxDrNLe9Kfme3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784256320&installation_id=130740768&pr_number=286&repository=getformo%2Fsdk&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fsdk%2Fpull%2F286&signature=5179d2088a26dc9bbf2565aed0d6b99c71d5ac186bd21962d8c7f14915e99065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->