### PR TITLE
Normalize trailing slashes in page URLs

### DIFF
--- a/src/event/EventFactory.ts
+++ b/src/event/EventFactory.ts
@@ -126,6 +126,17 @@ class EventFactory implements IEventFactory {
   }
 
   /**
+   * Normalize URL paths for analytics aggregation by stripping trailing slashes
+   * from non-root paths. Query strings and hash fragments are preserved by
+   * mutating only the URL pathname.
+   */
+  private normalizeUrlPath(url: URL): void {
+    if (url.pathname !== "/") {
+      url.pathname = url.pathname.replace(/\/+$/, "");
+    }
+  }
+
+  /**
    * Strip excluded (sensitive) query parameters from a URL in place. Only the
    * query string is touched; the path and hash/fragment are left as-is.
    */
@@ -142,15 +153,16 @@ class EventFactory implements IEventFactory {
   }
 
   /**
-   * Return the given absolute URL with excluded query parameters removed. The
-   * input is returned unchanged when it is empty or cannot be parsed (e.g. an
-   * empty referrer).
+   * Return the given absolute URL with excluded query parameters removed and
+   * trailing slashes stripped from non-root paths. The input is returned
+   * unchanged when it is empty or cannot be parsed (e.g. an empty referrer).
    */
   private redactUrl(href: string): string {
     if (!href) return href;
     try {
       const url = new URL(href);
       this.redactQueryParams(url);
+      this.normalizeUrlPath(url);
       return url.href;
     } catch {
       return href;
@@ -410,6 +422,7 @@ class EventFactory implements IEventFactory {
     try {
       urlObj = new URL(globalThis.location.href);
       this.redactQueryParams(urlObj);
+      this.normalizeUrlPath(urlObj);
     } catch {}
 
     if (isUndefined(pageProps.url)) {
@@ -417,7 +430,7 @@ class EventFactory implements IEventFactory {
     }
 
     if (isUndefined(pageProps.path)) {
-      pageProps.path = globalThis.location.pathname;
+      pageProps.path = urlObj ? urlObj.pathname : globalThis.location.pathname;
     }
 
     if (isUndefined(pageProps.hash)) {

--- a/test/lib/event/PagePropertiesParsing.spec.ts
+++ b/test/lib/event/PagePropertiesParsing.spec.ts
@@ -223,6 +223,32 @@ describe("Page Event Property Parsing", () => {
       expect(props.hash).to.equal("");
       expect(props.query).to.equal("");
     });
+
+    it("should strip trailing slashes from non-root page URL and path", async () => {
+      setMockLocation("https://formo.so/limit/bnb/?foo=bar#intro");
+
+      const props = await getPageProperties();
+      const context = await getPageContext();
+
+      expect(props.url).to.equal("https://formo.so/limit/bnb?foo=bar#intro");
+      expect(props.path).to.equal("/limit/bnb");
+      expect(props.hash).to.equal("#intro");
+      expect(props.query).to.equal("foo=bar");
+      expect(context.page_url).to.equal(
+        "https://formo.so/limit/bnb?foo=bar#intro"
+      );
+    });
+
+    it("should preserve the root slash when normalizing page URL and path", async () => {
+      setMockLocation("https://formo.so/?foo=bar#intro");
+
+      const props = await getPageProperties();
+      const context = await getPageContext();
+
+      expect(props.url).to.equal("https://formo.so/?foo=bar#intro");
+      expect(props.path).to.equal("/");
+      expect(context.page_url).to.equal("https://formo.so/?foo=bar#intro");
+    });
   });
 
   describe("Query parameter parsing", () => {
@@ -854,4 +880,3 @@ describe("Page Event Property Parsing", () => {
     });
   });
 });
-


### PR DESCRIPTION
### Motivation
- Analytics page URLs and page properties should be canonicalized so that routes with and without trailing slashes are deduplicated for reporting and dropdowns.
- Trailing-slash normalization should not change the root `/` and must preserve query strings and hash fragments.

### Description
- Add a private `normalizeUrlPath(url: URL)` helper to strip trailing slashes from non-root pathnames and call it from `redactUrl` and the page-properties parsing path in `getPageProperties` (file `src/event/EventFactory.ts`).
- Apply normalization when building the context `page_url` (via `redactUrl`) and when populating page properties so `url`/`path` reflect the normalized path while preserving `?query` and `#hash`.
- Use the parsed `URL` (`urlObj.pathname`) for `pageProps.path` instead of `globalThis.location.pathname` so the normalized pathname is used when available.
- Add tests in `test/lib/event/PagePropertiesParsing.spec.ts` that assert non-root trailing-slash stripping (`/limit/bnb/` → `/limit/bnb`) and root-path preservation (`/` remains `/`).

### Testing
- Ran lint with `pnpm lint` and it completed successfully.
- Ran the page properties tests with `pnpm test -- test/lib/event/PagePropertiesParsing.spec.ts` and the tests (including the two new assertions) passed as part of the full suite (`651 passing`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a466d2663cc8329aa4af80d2cae2ce4)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getformo/codesmith/sdk/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785592644&installation_id=130740768&pr_number=301&repository=getformo%2Fsdk&return_to=https%3A%2F%2Fgithub.com%2Fgetformo%2Fsdk%2Fpull%2F301&signature=2d4a574d8ce957b838e50260e8b407968f30eb786e2583e4959b7e5429fe0096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->